### PR TITLE
feat: add rov_name to RovConfig model

### DIFF
--- a/src/rov_firmware/models/config.py
+++ b/src/rov_firmware/models/config.py
@@ -140,6 +140,7 @@ class RovConfig(CamelCaseModel):
     """Main ROV configuration."""
 
     firmware_version: str = CURRENT_FIRMWARE_VERSION
+    rov_name: str = "Manafish Nomad"
     microcontroller_firmware_variant: MicrocontrollerFirmwareVariant = (
         MicrocontrollerFirmwareVariant.DSHOT
     )

--- a/src/rov_firmware/models/config.py
+++ b/src/rov_firmware/models/config.py
@@ -1,45 +1,24 @@
 """Configuration models for the ROV firmware."""
 
-from enum import StrEnum
 import json
+import secrets
+from enum import StrEnum
 from pathlib import Path
-import random
-import tomllib
 from typing import Any, ClassVar
 
 import numpy as np
+import tomllib
 from numpy.typing import NDArray as NumpyNDArray
 from numpydantic import NDArray, Shape
 from pydantic import Field, field_validator
 
 from .base import CamelCaseModel
 
-_ROV_NAME_SUFFIXES = [
-    "Nomad",
-    "Voyager",
-    "Drifter",
-    "Mariner",
-    "Pioneer",
-    "Surveyor",
-    "Wanderer",
-    "Pathfinder",
-    "Corsair",
-    "Triton",
-    "Nereid",
-    "Kraken",
-    "Leviathan",
-    "Nautilus",
-    "Poseidon",
-    "Abyss",
-    "Riptide",
-    "Tempest",
-    "Typhoon",
-    "Maelstrom",
-]
+_ROV_NAME_HEX_LENGTH = 4
 
 
 def _generate_rov_name() -> str:
-    return f"Manafish {random.choice(_ROV_NAME_SUFFIXES)}"  # noqa: S311
+    return f"Manafish-{secrets.token_hex(_ROV_NAME_HEX_LENGTH)}"
 
 
 _pyproject_path = Path(__file__).parents[3] / "pyproject.toml"

--- a/src/rov_firmware/models/config.py
+++ b/src/rov_firmware/models/config.py
@@ -3,15 +3,43 @@
 from enum import StrEnum
 import json
 from pathlib import Path
+import random
 import tomllib
 from typing import Any, ClassVar
 
 import numpy as np
 from numpy.typing import NDArray as NumpyNDArray
 from numpydantic import NDArray, Shape
-from pydantic import field_validator
+from pydantic import Field, field_validator
 
 from .base import CamelCaseModel
+
+_ROV_NAME_SUFFIXES = [
+    "Nomad",
+    "Voyager",
+    "Drifter",
+    "Mariner",
+    "Pioneer",
+    "Surveyor",
+    "Wanderer",
+    "Pathfinder",
+    "Corsair",
+    "Triton",
+    "Nereid",
+    "Kraken",
+    "Leviathan",
+    "Nautilus",
+    "Poseidon",
+    "Abyss",
+    "Riptide",
+    "Tempest",
+    "Typhoon",
+    "Maelstrom",
+]
+
+
+def _generate_rov_name() -> str:
+    return f"Manafish {random.choice(_ROV_NAME_SUFFIXES)}"  # noqa: S311
 
 
 _pyproject_path = Path(__file__).parents[3] / "pyproject.toml"
@@ -140,7 +168,7 @@ class RovConfig(CamelCaseModel):
     """Main ROV configuration."""
 
     firmware_version: str = CURRENT_FIRMWARE_VERSION
-    rov_name: str = "Manafish Nomad"
+    rov_name: str = Field(default_factory=_generate_rov_name)
     microcontroller_firmware_variant: MicrocontrollerFirmwareVariant = (
         MicrocontrollerFirmwareVariant.DSHOT
     )

--- a/src/tools/mock_websocket_server.py
+++ b/src/tools/mock_websocket_server.py
@@ -15,6 +15,7 @@ from websockets import ServerConnection
 PORT = 9000
 MOCK_CONFIG: dict[str, Any] = {
     "firmwareVersion": "1.0.0",
+    "rovName": "Manafish-m0ck",
     "microcontrollerFirmwareVariant": "dshot",
     "fluidType": "saltwater",
     "smoothingFactor": 0.0,


### PR DESCRIPTION
## Summary
- Added `rov_name` to the `RovConfig` model with default value 'Manafish Nomad'
- This enables synchronization of custom ROV names between the frontend app and the drone's firmware configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ROV name setting with default value of "Manafish Nomad".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->