### PR TITLE
Depth hold derivative fix

### DIFF
--- a/src/rov_firmware/regulator.py
+++ b/src/rov_firmware/regulator.py
@@ -445,7 +445,7 @@ class Regulator:
         depth_regulator_actuation = (
             float(config.depth.kp) * error
             + float(config.depth.ki) * float(self.integral_depth)
-            + float(config.depth.kd) * self.state.pressure.depth_change
+            - float(config.depth.kd) * self.state.pressure.depth_change
         )
 
         return depth_regulator_actuation

--- a/tests/test_regulator.py
+++ b/tests/test_regulator.py
@@ -107,7 +107,7 @@ def test_handle_depth_hold_computes_pid(rov_state):
 
     error = 3.0
     expected_integral = 0.5 + error * 0.1 * 0.75
-    expected_actuation = 2.0 * error + 3.0 * expected_integral + 4.0 * 1.2
+    expected_actuation = 2.0 * error + 3.0 * expected_integral - 4.0 * 1.2
 
     assert regulator.integral_depth == pytest.approx(expected_integral)
     assert actuation == pytest.approx(expected_actuation)


### PR DESCRIPTION
The sign was wrong on the depth hold derivative, this fixes it. Not tested but litteraly one character changes, so very confident no breaking bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved depth control accuracy by correcting the regulator’s control response calculation, resulting in more stable and precise depth maintenance and smoother underwater maneuvers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->