### PR TITLE
feat(networking): support Android USB Ethernet

### DIFF
--- a/nix/networking.nix
+++ b/nix/networking.nix
@@ -61,6 +61,11 @@
 
     ${nmcli} connection up "$CONNECTION"
     ${systemctl} restart --no-block dnsmasq.service
+
+    # At runtime the firmware server is still bound to the previous address.
+    # Restart it so it binds the new address; at boot try-restart is a no-op
+    # and the normal service ordering starts it later.
+    ${systemctl} try-restart --no-block manafish-firmware.service
   '';
 in {
   networking = {
@@ -82,15 +87,17 @@ in {
   # dnsmasq configuration.
   systemd.tmpfiles.rules = ["d /run/manafish 0755 pi users -"];
 
-  # Applying a new ROV address must also reload the matching DHCP pool. Limit
-  # the firmware user to managing only dnsmasq through systemd.
+  # Applying a new ROV address must reload the matching DHCP pool and rebind
+  # the firmware server. Limit the firmware user to those two units.
   security.polkit = {
     enable = true;
     extraConfig = ''
       polkit.addRule(function (action, subject) {
         if (
           action.id == "org.freedesktop.systemd1.manage-units" &&
-          action.lookup("unit") == "dnsmasq.service" &&
+          ["dnsmasq.service", "manafish-firmware.service"].indexOf(
+            action.lookup("unit")
+          ) >= 0 &&
           subject.user == "pi"
         ) {
           return polkit.Result.YES;

--- a/nix/networking.nix
+++ b/nix/networking.nix
@@ -60,7 +60,7 @@
     fi
 
     ${nmcli} connection up "$CONNECTION"
-    ${systemctl} try-restart --no-block dnsmasq.service
+    ${systemctl} restart --no-block dnsmasq.service
   '';
 in {
   networking = {

--- a/nix/networking.nix
+++ b/nix/networking.nix
@@ -5,17 +5,44 @@
 }: let
   jq = lib.getExe pkgs.jq;
   nmcli = lib.getExe' pkgs.networkmanager "nmcli";
+  python = lib.getExe pkgs.python3;
+  systemctl = lib.getExe' pkgs.systemd "systemctl";
+  dnsmasqConfig = "/run/manafish/dnsmasq.conf";
 
   networkScript = pkgs.writeShellScriptBin "manafish-network" ''
+    set -euo pipefail
+
     CONFIG="/home/pi/firmware/src/rov_firmware/config.json"
     DEFAULT_IP="10.10.10.10"
     PREFIX="24"
     CONNECTION="eth0"
+    DNSMASQ_CONFIG="${dnsmasqConfig}"
 
     if [ -f "$CONFIG" ]; then
       IP=$(${jq} -r '.ipAddress // empty' "$CONFIG" 2>/dev/null)
     fi
     IP="''${IP:-$DEFAULT_IP}"
+
+    ${python} - "$IP" "$DNSMASQ_CONFIG" <<'PY'
+    from ipaddress import IPv4Address, IPv4Network
+    from pathlib import Path
+    import sys
+
+    address = IPv4Address(sys.argv[1])
+    network = IPv4Network(f"{address}/24", strict=False)
+    if address in (network.network_address, network.broadcast_address):
+        raise ValueError(f"{address} is not a usable /24 host address")
+
+    host = int(address) - int(network.network_address)
+    start_host, end_host = (50, 100) if 150 <= host <= 200 else (150, 200)
+    start = IPv4Address(int(network.network_address) + start_host)
+    end = IPv4Address(int(network.network_address) + end_host)
+
+    Path(sys.argv[2]).write_text(
+        f"dhcp-range={start},{end},255.255.255.0,12h\n",
+        encoding="utf-8",
+    )
+    PY
 
     if ${nmcli} connection show "$CONNECTION" &>/dev/null; then
       ${nmcli} connection modify "$CONNECTION" \
@@ -33,6 +60,7 @@
     fi
 
     ${nmcli} connection up "$CONNECTION"
+    ${systemctl} try-restart --no-block dnsmasq.service
   '';
 in {
   networking = {
@@ -49,6 +77,28 @@ in {
 
   environment.systemPackages = [networkScript];
 
+  # The network helper is run by root during boot and by `pi` after a runtime
+  # config change. Give both paths one transient location for the subnet-aware
+  # dnsmasq configuration.
+  systemd.tmpfiles.rules = ["d /run/manafish 0755 pi users -"];
+
+  # Applying a new ROV address must also reload the matching DHCP pool. Limit
+  # the firmware user to managing only dnsmasq through systemd.
+  security.polkit = {
+    enable = true;
+    extraConfig = ''
+      polkit.addRule(function (action, subject) {
+        if (
+          action.id == "org.freedesktop.systemd1.manage-units" &&
+          action.lookup("unit") == "dnsmasq.service" &&
+          subject.user == "pi"
+        ) {
+          return polkit.Result.YES;
+        }
+      });
+    '';
+  };
+
   services = {
     avahi = {
       enable = true;
@@ -57,6 +107,30 @@ in {
       publish = {
         enable = true;
         addresses = true;
+      };
+    };
+    dnsmasq = {
+      enable = true;
+      resolveLocalQueries = false;
+      settings = {
+        interface = "eth0";
+        bind-dynamic = true;
+        port = 0;
+        dhcp-authoritative = true;
+        conf-file = dnsmasqConfig;
+
+        # Android identifies its DHCP client with an android-dhcp-* vendor
+        # class. It requires router and DNS options before treating Ethernet
+        # as provisioned, even though this isolated link provides neither
+        # service. Other clients receive no default route or DNS server, so a
+        # laptop's normal internet connection is not replaced by the tether.
+        dhcp-vendorclass = "set:android,android-dhcp-";
+        dhcp-option = [
+          "option:router"
+          "option:dns-server"
+          "tag:android,option:router,0.0.0.0"
+          "tag:android,option:dns-server,0.0.0.0"
+        ];
       };
     };
     openssh = {
@@ -74,5 +148,10 @@ in {
       RemainAfterExit = true;
       ExecStart = lib.getExe networkScript;
     };
+  };
+
+  systemd.services.dnsmasq = {
+    after = ["manafish-network.service"];
+    requires = ["manafish-network.service"];
   };
 }

--- a/src/rov_firmware/websocket/receive/config.py
+++ b/src/rov_firmware/websocket/receive/config.py
@@ -45,6 +45,22 @@ def _apply_ip_address(ip_address: str) -> None:
         log_warn(f"Failed to apply IP address change to {ip_address}.")
 
 
+def _restart_firmware() -> None:
+    path = shutil.which("systemctl")
+    if path is None:
+        log_warn("systemctl not found in PATH.")
+        return
+    try:
+        subprocess.run(  # noqa: S603
+            [path, "try-restart", "--no-block", "manafish-firmware.service"],
+            check=True,
+            capture_output=True,
+        )
+        log_info("Restarting firmware to apply the WebSocket port change.")
+    except subprocess.CalledProcessError:
+        log_warn("Failed to restart firmware after the WebSocket port change.")
+
+
 def _apply_camera() -> None:
     path = shutil.which("manafish-camera")
     if path is None:
@@ -72,6 +88,7 @@ async def handle_set_config(
         payload: Partial ROV configuration update.
     """
     old_ip = state.rov_config.ip_address
+    old_websocket_port = state.rov_config.websocket_port
     previous_camera = state.rov_config.camera
     current_data = state.rov_config.model_dump(by_alias=False)
     update_data = payload.model_dump(by_alias=False, include=payload.model_fields_set)
@@ -89,6 +106,8 @@ async def handle_set_config(
             action=None,
         )
         _apply_ip_address(state.rov_config.ip_address)
+    elif state.rov_config.websocket_port != old_websocket_port:
+        _restart_firmware()
 
     if state.rov_config.camera != previous_camera:
         _apply_camera()
@@ -136,6 +155,7 @@ async def handle_import_config(
             newer firmware version.
     """
     old_ip = state.rov_config.ip_address
+    old_websocket_port = state.rov_config.websocket_port
     previous_camera = state.rov_config.camera
     raw = apply_migrations(dict(payload))
     _strip_device_reported(raw)
@@ -164,6 +184,8 @@ async def handle_import_config(
             action=None,
         )
         _apply_ip_address(state.rov_config.ip_address)
+    elif state.rov_config.websocket_port != old_websocket_port:
+        _restart_firmware()
 
     if state.rov_config.camera != previous_camera:
         _apply_camera()

--- a/src/rov_firmware/websocket/receive/config.py
+++ b/src/rov_firmware/websocket/receive/config.py
@@ -1,5 +1,6 @@
 """WebSocket config handlers for the ROV firmware."""
 
+import asyncio
 import shutil
 import subprocess
 from typing import Any
@@ -15,6 +16,7 @@ from ..queue import get_message_queue
 
 
 _DEVICE_REPORTED_FIELDS = ("firmwareVersion", "mcuFirmwareVersion")
+_SYSTEMCTL_TIMEOUT_SECONDS = 5.0
 
 
 async def handle_get_config(
@@ -45,20 +47,43 @@ def _apply_ip_address(ip_address: str) -> None:
         log_warn(f"Failed to apply IP address change to {ip_address}.")
 
 
-def _restart_firmware() -> None:
+async def _restart_firmware() -> bool:
     path = shutil.which("systemctl")
     if path is None:
         log_warn("systemctl not found in PATH.")
-        return
+        return False
     try:
-        subprocess.run(  # noqa: S603
-            [path, "try-restart", "--no-block", "manafish-firmware.service"],
-            check=True,
-            capture_output=True,
+        process = await asyncio.create_subprocess_exec(
+            path,
+            "try-restart",
+            "--no-block",
+            "manafish-firmware.service",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
         )
-        log_info("Restarting firmware to apply the WebSocket port change.")
-    except subprocess.CalledProcessError:
-        log_warn("Failed to restart firmware after the WebSocket port change.")
+    except OSError as error:
+        log_warn(f"Failed to start systemctl: {error}.")
+        return False
+
+    try:
+        _, stderr = await asyncio.wait_for(
+            process.communicate(),
+            timeout=_SYSTEMCTL_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        log_warn("Timed out while requesting the firmware restart.")
+        return False
+
+    if process.returncode != 0:
+        details = stderr.decode(errors="replace").strip()
+        suffix = f": {details}" if details else "."
+        log_warn(f"Failed to restart firmware after the WebSocket port change{suffix}")
+        return False
+
+    log_info("Restarting firmware to apply the WebSocket port change.")
+    return True
 
 
 def _apply_camera() -> None:
@@ -96,6 +121,7 @@ async def handle_set_config(
     state.rov_config = RovConfig.model_validate(current_data)
     state.rov_config.save()
     log_info("Received and applied config update.")
+    connection_restart_failed = False
 
     if state.rov_config.ip_address != old_ip:
         toast_info(
@@ -107,10 +133,20 @@ async def handle_set_config(
         )
         _apply_ip_address(state.rov_config.ip_address)
     elif state.rov_config.websocket_port != old_websocket_port:
-        _restart_firmware()
+        connection_restart_failed = not await _restart_firmware()
 
     if state.rov_config.camera != previous_camera:
         _apply_camera()
+
+    if connection_restart_failed:
+        toast_warn(
+            identifier=None,
+            content=ToastContent(
+                message_key="toasts_rov_connection_restart_failed",
+            ),
+            action=None,
+        )
+        return
 
     toast_success(
         identifier=None,
@@ -176,6 +212,7 @@ async def handle_import_config(
     log_info(
         f"Imported config from app. Skipped fields: {skipped or 'none'}.",
     )
+    connection_restart_failed = False
 
     if state.rov_config.ip_address != old_ip:
         toast_info(
@@ -185,10 +222,20 @@ async def handle_import_config(
         )
         _apply_ip_address(state.rov_config.ip_address)
     elif state.rov_config.websocket_port != old_websocket_port:
-        _restart_firmware()
+        connection_restart_failed = not await _restart_firmware()
 
     if state.rov_config.camera != previous_camera:
         _apply_camera()
+
+    if connection_restart_failed:
+        toast_warn(
+            identifier=None,
+            content=ToastContent(
+                message_key="toasts_rov_connection_restart_failed",
+            ),
+            action=None,
+        )
+        return
 
     if skipped:
         toast_warn(

--- a/tests/test_import_config.py
+++ b/tests/test_import_config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from rov_firmware.models.config import RovConfig
+from rov_firmware.websocket.receive import config as config_handlers
 from rov_firmware.websocket.receive.config import handle_import_config
 
 
@@ -85,3 +86,38 @@ def test_import_persists_to_disk(rov_state, isolated_config_path):
 
     assert isolated_config_path.exists()
     assert "Persisted" in isolated_config_path.read_text()
+
+
+def test_import_restarts_firmware_when_websocket_port_changed(rov_state, monkeypatch):
+    restart_calls: list[None] = []
+
+    async def restart_firmware() -> bool:
+        restart_calls.append(None)
+        return True
+
+    monkeypatch.setattr(config_handlers, "_restart_firmware", restart_firmware)
+
+    payload = _baseline_export(rov_state)
+    payload["websocketPort"] = 9100
+    asyncio.run(handle_import_config(rov_state, payload))
+
+    assert restart_calls == [None]
+
+
+def test_import_applies_network_once_when_ip_and_port_changed(rov_state, monkeypatch):
+    network_calls: list[str] = []
+    restart_calls: list[None] = []
+
+    async def restart_firmware() -> bool:
+        restart_calls.append(None)
+        return True
+
+    monkeypatch.setattr(config_handlers, "_apply_ip_address", network_calls.append)
+    monkeypatch.setattr(config_handlers, "_restart_firmware", restart_firmware)
+
+    payload = _baseline_export(rov_state)
+    payload.update({"ipAddress": "10.10.11.10", "websocketPort": 9100})
+    asyncio.run(handle_import_config(rov_state, payload))
+
+    assert network_calls == ["10.10.11.10"]
+    assert restart_calls == []

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -83,3 +83,40 @@ def test_set_config_applies_camera_only_when_camera_changed(rov_state, monkeypat
     camera_payload = PartialRovConfig.model_validate({"camera": {"framerate": 24}})
     asyncio.run(handle_set_config(rov_state, camera_payload))
     assert apply_calls == [None]
+
+
+def test_set_config_restarts_firmware_when_websocket_port_changed(
+    rov_state, monkeypatch
+):
+    restart_calls: list[None] = []
+    monkeypatch.setattr(
+        config_handlers, "_restart_firmware", lambda: restart_calls.append(None)
+    )
+
+    payload = PartialRovConfig.model_validate({"websocketPort": 9100})
+    asyncio.run(handle_set_config(rov_state, payload))
+
+    assert restart_calls == [None]
+
+
+def test_set_config_applies_network_once_when_ip_and_port_changed(
+    rov_state, monkeypatch
+):
+    network_calls: list[str] = []
+    restart_calls: list[None] = []
+    monkeypatch.setattr(
+        config_handlers,
+        "_apply_ip_address",
+        network_calls.append,
+    )
+    monkeypatch.setattr(
+        config_handlers, "_restart_firmware", lambda: restart_calls.append(None)
+    )
+
+    payload = PartialRovConfig.model_validate(
+        {"ipAddress": "10.10.11.10", "websocketPort": 9100}
+    )
+    asyncio.run(handle_set_config(rov_state, payload))
+
+    assert network_calls == ["10.10.11.10"]
+    assert restart_calls == []

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -89,9 +89,12 @@ def test_set_config_restarts_firmware_when_websocket_port_changed(
     rov_state, monkeypatch
 ):
     restart_calls: list[None] = []
-    monkeypatch.setattr(
-        config_handlers, "_restart_firmware", lambda: restart_calls.append(None)
-    )
+
+    async def restart_firmware() -> bool:
+        restart_calls.append(None)
+        return True
+
+    monkeypatch.setattr(config_handlers, "_restart_firmware", restart_firmware)
 
     payload = PartialRovConfig.model_validate({"websocketPort": 9100})
     asyncio.run(handle_set_config(rov_state, payload))
@@ -109,9 +112,12 @@ def test_set_config_applies_network_once_when_ip_and_port_changed(
         "_apply_ip_address",
         network_calls.append,
     )
-    monkeypatch.setattr(
-        config_handlers, "_restart_firmware", lambda: restart_calls.append(None)
-    )
+
+    async def restart_firmware() -> bool:
+        restart_calls.append(None)
+        return True
+
+    monkeypatch.setattr(config_handlers, "_restart_firmware", restart_firmware)
 
     payload = PartialRovConfig.model_validate(
         {"ipAddress": "10.10.11.10", "websocketPort": 9100}
@@ -120,3 +126,29 @@ def test_set_config_applies_network_once_when_ip_and_port_changed(
 
     assert network_calls == ["10.10.11.10"]
     assert restart_calls == []
+
+
+def test_set_config_reports_restart_failure_without_success(rov_state, monkeypatch):
+    success_calls: list[None] = []
+    warning_keys: list[str] = []
+
+    async def restart_firmware() -> bool:
+        return False
+
+    monkeypatch.setattr(config_handlers, "_restart_firmware", restart_firmware)
+    monkeypatch.setattr(
+        config_handlers,
+        "toast_success",
+        lambda **_kwargs: success_calls.append(None),
+    )
+    monkeypatch.setattr(
+        config_handlers,
+        "toast_warn",
+        lambda *, content, **_kwargs: warning_keys.append(content.message_key),
+    )
+
+    payload = PartialRovConfig.model_validate({"websocketPort": 9100})
+    asyncio.run(handle_set_config(rov_state, payload))
+
+    assert success_calls == []
+    assert warning_keys == ["toasts_rov_connection_restart_failed"]


### PR DESCRIPTION
## Summary

- run a DHCP-only dnsmasq instance on the ROV Ethernet interface
- derive the DHCP pool from the configured ROV /24 subnet
- avoid the ROV address by switching between host ranges 150-200 and 50-100
- regenerate the pool and restart dnsmasq whenever the ROV IP changes
- restart the firmware after IP or WebSocket-port changes so it binds the new endpoint
- send Android-required router and DNS fields only to `android-dhcp-*` clients
- leave other clients without a DHCP default route or DNS server

## Why

Android needs an address, default route, and DNS server in its DHCP lease before it treats USB Ethernet as provisioned. The ROV advertises placeholder router and DNS values only to Android clients; dnsmasq DNS remains disabled and the ROV does not forward internet traffic.

The ROV keeps its configurable static address. dnsmasq follows the same /24, so multiple ROVs can use distinct subnets such as `10.10.10.10/24` and `10.10.11.10/24` without manual client configuration. Restarting the firmware after a connection change ensures its WebSocket server binds the new address or port immediately instead of requiring a reboot.

## App compatibility and merge order

Companion app PR: https://github.com/manafishrov/app/pull/170

Merge/release this firmware change first. Older apps can still select the new address manually. The app PR then makes the handoff automatic and waits for the ROV update to reach the current WebSocket before reconnecting.

## Scope

This supersedes the network portion of #68. The diff is limited to networking configuration, the runtime connection apply path, and focused tests. It contains no README, camera, or mock-server changes.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check` (two pre-existing warnings)
- `uv run pytest` (108 passed)
- `nix fmt`
- `nix flake check --no-build`
- full `nix build .#default` SD image build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved network setup for more reliable isolated DHCP connectivity on `eth0`.
  * DHCP ranges now automatically match the active subnet.
  * Added Android-specific network behavior with appropriate router and DNS settings.
  * Network services now start in the correct order and recover more consistently after interface setup.
  * Added controlled service management permissions for the designated system user.
  * Firmware now restarts automatically when the WebSocket port configuration changes.

* **Bug Fixes**
  * Prevented redundant network updates when IP address and WebSocket port changes are applied together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
