### PR TITLE
fix(firmware): harden settings and MCU coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,29 @@ Select the SD card from the "Device" dropdown.
 Click "Select" and choose the extracted .img file.
 Click "Start" to begin flashing the SD card.
 
+## Ethernet Connections
+
+The ROV uses `10.10.10.10/24` by default. Connect a computer, phone, or tablet
+to its Ethernet port and use that address in the app. The DHCP server assigns
+clients an address from the same `/24` subnet without changing the ROV's own
+static address.
+
+Android phones and tablets can connect through a USB-C Ethernet adapter without
+manual network configuration. Android requires router and DNS fields before it
+considers an Ethernet link usable, so the ROV supplies placeholder values only
+to clients identifying themselves as Android. The ROV does not provide DNS or
+forward internet traffic; the device can therefore keep using Wi-Fi for normal
+internet access. An Android "no internet" indication for the Ethernet link is
+expected.
+
+Desktop clients receive an address but no default route or DNS server, so the
+tether does not replace their existing internet connection. A manual address in
+the same subnet, such as `10.10.10.100/24`, also works.
+
+If the ROV address is changed in the app, its DHCP pool follows the selected
+`/24` subnet automatically. Reconnect the Ethernet adapter if a client retains
+an old lease after that change.
+
 ## Development Hooks
 
 Install the development dependencies and Git hook once per clone:

--- a/flake.lock
+++ b/flake.lock
@@ -92,25 +92,25 @@
     "mcu-firmware-pico": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-lEzXurXmW6Zkhpona7BDqHISf+dDC9CrYYc+Vx8K5O4=",
+        "narHash": "sha256-UUP5U2SRWsvNmzxgA+/fIB6IcoRogZ45DAqogU+rGBE=",
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.2/pico-v1.0.2.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.1/pico-v1.0.3-rc.1.uf2"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.2/pico-v1.0.2.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.1/pico-v1.0.3-rc.1.uf2"
       }
     },
     "mcu-firmware-pico2": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-4+tiVwAMUtcFv0LO1C4bRys3qTXgNyap5T07Ms9+J+8=",
+        "narHash": "sha256-h+UL1BzruPVS3rfaJfd/fS+WcTqZORaaoaMjjK3p/O8=",
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.2/pico2-v1.0.2.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.1/pico2-v1.0.3-rc.1.uf2"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.2/pico2-v1.0.2.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.1/pico2-v1.0.3-rc.1.uf2"
       }
     },
     "ms5837-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,11 +40,11 @@
       flake = false;
     };
     mcu-firmware-pico = {
-      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.2/pico-v1.0.2.uf2";
+      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.1/pico-v1.0.3-rc.1.uf2";
       flake = false;
     };
     mcu-firmware-pico2 = {
-      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.2/pico2-v1.0.2.uf2";
+      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.1/pico2-v1.0.3-rc.1.uf2";
       flake = false;
     };
   };
@@ -57,7 +57,7 @@
     treefmt-nix,
     ...
   } @ inputs: let
-    mcuFirmwareVersion = "v1.0.2";
+    mcuFirmwareVersion = "v1.0.3-rc.1";
     supportedSystems = [
       "aarch64-linux"
       "x86_64-linux"

--- a/nix/camera.nix
+++ b/nix/camera.nix
@@ -71,6 +71,11 @@
     # The Pi 3 hardware H.264 encoder is limited to a 1920x1080 output frame.
     WIDTH=$(clamp_int "$(get .camera.width)" 160 1920 1440)
     HEIGHT=$(clamp_int "$(get .camera.height)" 160 1080 1080)
+    # H.264 and the camera scaler require complete chroma pairs. The Python
+    # model already enforces this, but repeat it here for manually edited or
+    # otherwise corrupted persisted configuration.
+    WIDTH=$(( WIDTH - WIDTH % 2 ))
+    HEIGHT=$(( HEIGHT - HEIGHT % 2 ))
     CROP_FOV=$(get .camera.cropFov)
 
     # Repeat the firmware model's resolution-aware limit here because go2rtc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.1.6"
+version = "1.1.5"
 description = "Firmware for the Manafish ROV"
 license = "AGPL-3.0-or-later"
 requires-python = "==3.13.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.1.5"
+version = "1.1.6"
 description = "Firmware for the Manafish ROV"
 license = "AGPL-3.0-or-later"
 requires-python = "==3.13.14"

--- a/src/rov_firmware/main.py
+++ b/src/rov_firmware/main.py
@@ -64,6 +64,9 @@ async def main() -> None:
 
         tasks = [
             asyncio.create_task(imu.read_loop(), name="imu.read_loop"),
+            asyncio.create_task(
+                regulator.imu_update_loop(), name="regulator.imu_update_loop"
+            ),
             asyncio.create_task(pressure.read_loop(), name="pressure.read_loop"),
             asyncio.create_task(mcu.read_loop(), name="mcu.read_loop"),
             asyncio.create_task(thrusters.send_loop(), name="thrusters.send_loop"),

--- a/src/rov_firmware/models/config.py
+++ b/src/rov_firmware/models/config.py
@@ -35,8 +35,10 @@ _DSHOT_1200 = 1200
 _PICO_SAFE_DSHOT_SPEED = 600
 
 
-def parse_semver(version: str) -> tuple[int, int, int]:
+def parse_semver(version: object) -> tuple[int, int, int]:
     """Parse semver string into (major, minor, patch) tuple."""
+    if not isinstance(version, str):
+        return (0, 0, 0)
     parts = version.split(".")
     major = int(parts[_MAJOR]) if len(parts) > _MAJOR and parts[_MAJOR].isdigit() else 0
     minor = int(parts[_MINOR]) if len(parts) > _MINOR and parts[_MINOR].isdigit() else 0
@@ -44,7 +46,7 @@ def parse_semver(version: str) -> tuple[int, int, int]:
     return (major, minor, patch)
 
 
-def compare_semver(a: str, b: str) -> int:
+def compare_semver(a: object, b: object) -> int:
     """Compare two semver strings. Returns -1, 0, or 1."""
     a_tuple = parse_semver(a)
     b_tuple = parse_semver(b)

--- a/src/rov_firmware/models/config.py
+++ b/src/rov_firmware/models/config.py
@@ -27,7 +27,6 @@ _pyproject_path = Path(__file__).parents[3] / "pyproject.toml"
 with _pyproject_path.open("rb") as _f:
     _pyproject = tomllib.load(_f)
 CURRENT_FIRMWARE_VERSION = _pyproject["project"]["version"]
-CURRENT_CONFIG_SCHEMA_VERSION = 1
 
 _MAJOR = 0
 _MINOR = 1
@@ -57,18 +56,14 @@ def compare_semver(a: str, b: str) -> int:
 
 
 def apply_migrations(raw: dict[str, Any]) -> dict[str, Any]:
-    """Apply config migrations based on firmware and config schema versions."""
+    """Apply config migrations based on firmware version."""
     firmware_version = raw.get("firmwareVersion", "0.0.0")
 
     if compare_semver(firmware_version, "1.1.0") == -1:
         raw.setdefault("nullspaceVectors", [])
         raw["firmwareVersion"] = "1.1.0"
 
-    schema_version = raw.get("configSchemaVersion", 0)
-    if not isinstance(schema_version, int) or isinstance(schema_version, bool):
-        schema_version = 0
-
-    if schema_version < CURRENT_CONFIG_SCHEMA_VERSION:
+    if compare_semver(firmware_version, "1.1.6") == -1:
         power = raw.get("power")
         if isinstance(power, dict):
             power.pop("internalResistance", None)
@@ -93,7 +88,7 @@ def apply_migrations(raw: dict[str, Any]) -> dict[str, Any]:
         ):
             raw["dshotSpeed"] = _PICO_SAFE_DSHOT_SPEED
 
-        raw["configSchemaVersion"] = CURRENT_CONFIG_SCHEMA_VERSION
+        raw["firmwareVersion"] = "1.1.6"
 
     return raw
 
@@ -422,7 +417,6 @@ class RovConfig(CamelCaseModel):
     """Main ROV configuration."""
 
     firmware_version: str = CURRENT_FIRMWARE_VERSION
-    config_schema_version: int = CURRENT_CONFIG_SCHEMA_VERSION
     mcu_firmware_version: str = ""
     rov_name: str = Field(default_factory=_generate_rov_name)
     mcu_board: McuBoard = McuBoard.PICO
@@ -535,34 +529,18 @@ class RovConfig(CamelCaseModel):
             return default_config
 
         stored_version = raw.get("firmwareVersion", "0.0.0")
-        stored_schema_version = raw.get("configSchemaVersion", 0)
 
         if compare_semver(stored_version, CURRENT_FIRMWARE_VERSION) > 0:
             return cls()
-        if (
-            isinstance(stored_schema_version, int)
-            and not isinstance(stored_schema_version, bool)
-            and stored_schema_version > CURRENT_CONFIG_SCHEMA_VERSION
-        ):
-            return cls()
 
-        migration_needed = (
-            stored_version != CURRENT_FIRMWARE_VERSION
-            or stored_schema_version != CURRENT_CONFIG_SCHEMA_VERSION
-        )
         raw = apply_migrations(raw)
         raw["firmwareVersion"] = CURRENT_FIRMWARE_VERSION
-        raw["configSchemaVersion"] = CURRENT_CONFIG_SCHEMA_VERSION
 
-        config = cls.model_validate(raw)
-        if migration_needed:
-            config.save()
-        return config
+        return cls.model_validate(raw)
 
     def save(self) -> None:
         """Save config to file with current firmware version."""
         self.firmware_version = CURRENT_FIRMWARE_VERSION
-        self.config_schema_version = CURRENT_CONFIG_SCHEMA_VERSION
         dir_path = self._config_path.parent
         tmp = Path(tempfile.mkstemp(dir=dir_path, suffix=".tmp")[1])
         try:

--- a/src/rov_firmware/models/config.py
+++ b/src/rov_firmware/models/config.py
@@ -27,6 +27,7 @@ _pyproject_path = Path(__file__).parents[3] / "pyproject.toml"
 with _pyproject_path.open("rb") as _f:
     _pyproject = tomllib.load(_f)
 CURRENT_FIRMWARE_VERSION = _pyproject["project"]["version"]
+CURRENT_CONFIG_SCHEMA_VERSION = 1
 
 _MAJOR = 0
 _MINOR = 1
@@ -56,14 +57,18 @@ def compare_semver(a: str, b: str) -> int:
 
 
 def apply_migrations(raw: dict[str, Any]) -> dict[str, Any]:
-    """Apply config migrations based on firmware version."""
+    """Apply config migrations based on firmware and config schema versions."""
     firmware_version = raw.get("firmwareVersion", "0.0.0")
 
     if compare_semver(firmware_version, "1.1.0") == -1:
         raw.setdefault("nullspaceVectors", [])
         raw["firmwareVersion"] = "1.1.0"
 
-    if compare_semver(firmware_version, "1.1.6") == -1:
+    schema_version = raw.get("configSchemaVersion", 0)
+    if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+        schema_version = 0
+
+    if schema_version < CURRENT_CONFIG_SCHEMA_VERSION:
         power = raw.get("power")
         if isinstance(power, dict):
             power.pop("internalResistance", None)
@@ -88,7 +93,7 @@ def apply_migrations(raw: dict[str, Any]) -> dict[str, Any]:
         ):
             raw["dshotSpeed"] = _PICO_SAFE_DSHOT_SPEED
 
-        raw["firmwareVersion"] = "1.1.6"
+        raw["configSchemaVersion"] = CURRENT_CONFIG_SCHEMA_VERSION
 
     return raw
 
@@ -417,6 +422,7 @@ class RovConfig(CamelCaseModel):
     """Main ROV configuration."""
 
     firmware_version: str = CURRENT_FIRMWARE_VERSION
+    config_schema_version: int = CURRENT_CONFIG_SCHEMA_VERSION
     mcu_firmware_version: str = ""
     rov_name: str = Field(default_factory=_generate_rov_name)
     mcu_board: McuBoard = McuBoard.PICO
@@ -529,18 +535,34 @@ class RovConfig(CamelCaseModel):
             return default_config
 
         stored_version = raw.get("firmwareVersion", "0.0.0")
+        stored_schema_version = raw.get("configSchemaVersion", 0)
 
         if compare_semver(stored_version, CURRENT_FIRMWARE_VERSION) > 0:
             return cls()
+        if (
+            isinstance(stored_schema_version, int)
+            and not isinstance(stored_schema_version, bool)
+            and stored_schema_version > CURRENT_CONFIG_SCHEMA_VERSION
+        ):
+            return cls()
 
+        migration_needed = (
+            stored_version != CURRENT_FIRMWARE_VERSION
+            or stored_schema_version != CURRENT_CONFIG_SCHEMA_VERSION
+        )
         raw = apply_migrations(raw)
         raw["firmwareVersion"] = CURRENT_FIRMWARE_VERSION
+        raw["configSchemaVersion"] = CURRENT_CONFIG_SCHEMA_VERSION
 
-        return cls.model_validate(raw)
+        config = cls.model_validate(raw)
+        if migration_needed:
+            config.save()
+        return config
 
     def save(self) -> None:
         """Save config to file with current firmware version."""
         self.firmware_version = CURRENT_FIRMWARE_VERSION
+        self.config_schema_version = CURRENT_CONFIG_SCHEMA_VERSION
         dir_path = self._config_path.parent
         tmp = Path(tempfile.mkstemp(dir=dir_path, suffix=".tmp")[1])
         try:

--- a/src/rov_firmware/models/config.py
+++ b/src/rov_firmware/models/config.py
@@ -31,6 +31,8 @@ CURRENT_FIRMWARE_VERSION = _pyproject["project"]["version"]
 _MAJOR = 0
 _MINOR = 1
 _PATCH = 2
+_DSHOT_1200 = 1200
+_PICO_SAFE_DSHOT_SPEED = 600
 
 
 def parse_semver(version: str) -> tuple[int, int, int]:
@@ -60,6 +62,33 @@ def apply_migrations(raw: dict[str, Any]) -> dict[str, Any]:
     if compare_semver(firmware_version, "1.1.0") == -1:
         raw.setdefault("nullspaceVectors", [])
         raw["firmwareVersion"] = "1.1.0"
+
+    if compare_semver(firmware_version, "1.1.6") == -1:
+        power = raw.get("power")
+        if isinstance(power, dict):
+            power.pop("internalResistance", None)
+
+        regulator = raw.get("regulator")
+        if isinstance(regulator, dict):
+            depth = regulator.get("depth")
+            if isinstance(depth, dict) and depth == {
+                "kp": 6,
+                "ki": 2,
+                "kd": 0.6,
+                "rate": 0.5,
+            }:
+                regulator["depth"] = {"kp": 2, "ki": 0, "kd": 0.5, "rate": 0.5}
+
+        # Older builds allowed this unsupported combination and silently ran
+        # it as DShot600. Preserve that effective setting when loading an old
+        # config, while rejecting new attempts to select it below.
+        if (
+            raw.get("mcuBoard", McuBoard.PICO.value) == McuBoard.PICO.value
+            and raw.get("dshotSpeed") == _DSHOT_1200
+        ):
+            raw["dshotSpeed"] = _PICO_SAFE_DSHOT_SPEED
+
+        raw["firmwareVersion"] = "1.1.6"
 
     return raw
 
@@ -146,7 +175,6 @@ class Power(CamelCaseModel):
     regulator_limit: int
     min_battery_voltage: float
     max_battery_voltage: float
-    internal_resistance: float = 0.1
 
     @field_validator("min_battery_voltage", "max_battery_voltage", mode="after")
     @classmethod
@@ -154,15 +182,6 @@ class Power(CamelCaseModel):
         """Validate that battery voltage is positive."""
         if v <= 0:
             msg = "Battery voltage must be positive"
-            raise ValueError(msg)
-        return v
-
-    @field_validator("internal_resistance", mode="after")
-    @classmethod
-    def validate_internal_resistance(cls, v: float) -> float:
-        """Validate that internal resistance is non-negative."""
-        if v < 0:
-            msg = "Internal resistance must be non-negative"
             raise ValueError(msg)
         return v
 
@@ -357,6 +376,43 @@ class Camera(CamelCaseModel):
         return self
 
 
+class PartialCamera(CamelCaseModel):
+    """Camera fields supplied by a partial configuration update."""
+
+    width: int | None = None
+    height: int | None = None
+    framerate: int | None = None
+    crop_fov: bool | None = None
+    bitrate: int | None = None
+    keyframe_interval: int | None = None
+    profile: H264Profile | None = None
+    level: H264Level | None = None
+    rotation: int | None = None
+    hflip: bool | None = None
+    vflip: bool | None = None
+    awb: AwbMode | None = None
+    exposure_value: float | None = None
+    brightness: float | None = None
+    contrast: float | None = None
+    saturation: float | None = None
+    sharpness: float | None = None
+    denoise: DenoiseMode | None = None
+
+    @model_validator(mode="after")
+    def reject_explicit_nulls(self) -> "PartialCamera":
+        """Reject nulls that cannot be applied to the complete camera config."""
+        null_fields = sorted(
+            field_name
+            for field_name in self.model_fields_set
+            if getattr(self, field_name) is None
+        )
+        if null_fields:
+            fields = ", ".join(null_fields)
+            msg = f"Camera fields cannot be null: {fields}"
+            raise ValueError(msg)
+        return self
+
+
 class RovConfig(CamelCaseModel):
     """Main ROV configuration."""
 
@@ -397,7 +453,7 @@ class RovConfig(CamelCaseModel):
         pitch=AxisConfig(kp=6, ki=2, kd=0.6, rate=120.0),
         roll=AxisConfig(kp=6, ki=2, kd=0.6, rate=120.0),
         yaw=AxisConfig(kp=6, ki=2, kd=0.6, rate=120.0),
-        depth=AxisConfig(kp=6, ki=2, kd=0.6, rate=0.5),
+        depth=AxisConfig(kp=2, ki=0, kd=0.5, rate=0.5),
         fpv_mode=False,
     )
     direction_coefficients: DirectionCoefficients = DirectionCoefficients(
@@ -424,6 +480,14 @@ class RovConfig(CamelCaseModel):
             msg = "DShot speed must be one of 150, 300, 600, 1200"
             raise ValueError(msg)
         return v
+
+    @model_validator(mode="after")
+    def validate_dshot_speed_for_board(self) -> "RovConfig":
+        """Reject DShot speeds unsupported by the selected MCU."""
+        if self.mcu_board == McuBoard.PICO and self.dshot_speed == _DSHOT_1200:
+            msg = "DShot1200 requires Pico 2"
+            raise ValueError(msg)
+        return self
 
     @field_validator("thruster_allocation", mode="before")
     @classmethod
@@ -510,7 +574,7 @@ class PartialRovConfig(CamelCaseModel):
     regulator: Regulator | None = None
     direction_coefficients: DirectionCoefficients | None = None
     power: Power | None = None
-    camera: Camera | None = None
+    camera: PartialCamera | None = None
     ip_address: str | None = None
     websocket_port: int | None = None
 

--- a/src/rov_firmware/regulator.py
+++ b/src/rov_firmware/regulator.py
@@ -1,5 +1,6 @@
 """Regulator module for ROV control (NED convention)."""
 
+import asyncio
 import time
 from typing import cast
 
@@ -140,7 +141,7 @@ class _MahonyAhrs:
         )
 
         # Error drives estimated up toward measured accel direction.
-        e = cast(NDArray[np.float32], np.cross(a, g_body))
+        e = np.cross(a, g_body)
 
         if self.ki > 0.0:
             self._integral += e * (self.ki * dt)
@@ -387,6 +388,19 @@ class Regulator:
         self.state.regulator.pitch = pitch
         self.state.regulator.roll = roll
         self.state.regulator.yaw = yaw
+
+    async def imu_update_loop(self) -> None:
+        """Update attitude continuously, independently of the MCU connection."""
+        interval = 1.0 / THRUSTER_SEND_FREQUENCY
+        next_tick = time.perf_counter() + interval
+        while True:
+            self.update_regulator_data_from_imu()
+            sleep_time = next_tick - time.perf_counter()
+            await asyncio.sleep(max(0.0, sleep_time))
+            next_tick += interval
+            now = time.perf_counter()
+            if next_tick < now:
+                next_tick = now + interval
 
     def _handle_edges(self) -> None:
         """Detect and handle rising-edge transitions for depth-hold and stabilization enable flags.

--- a/src/rov_firmware/sensors/mcu.py
+++ b/src/rov_firmware/sensors/mcu.py
@@ -291,19 +291,19 @@ class McuSensor:
             else ThrusterProtocol.PWM
         )
         dshot_speed = packet[5] | (packet[6] << 8)
-
-        changed = (
-            self.state.rov_config.mcu_firmware_version != version
-            or self.state.rov_config.thruster_protocol != protocol
-            or self.state.rov_config.dshot_speed != dshot_speed
+        acknowledged_config = (protocol.value, dshot_speed)
+        protocol_changed = (
+            self.serial_manager.mcu_protocol_config != acknowledged_config
         )
+        self.serial_manager.record_mcu_protocol_config(*acknowledged_config)
+
+        version_changed = self.state.rov_config.mcu_firmware_version != version
 
         self.state.rov_config.mcu_firmware_version = version
-        self.state.rov_config.thruster_protocol = protocol
-        self.state.rov_config.dshot_speed = dshot_speed
 
-        if changed:
+        if protocol_changed:
             self._reset_telemetry()
+        if version_changed or protocol_changed:
             get_message_queue().put_nowait(Config(payload=self.state.rov_config))
 
         expected = self._get_expected_version()

--- a/src/rov_firmware/serial.py
+++ b/src/rov_firmware/serial.py
@@ -29,6 +29,7 @@ class SerialManager:
         self._first_boot_retries: int = 0
         self._first_boot_flashed: bool = False
         self._connection_generation: int = 0
+        self._mcu_protocol_config: tuple[str, int] | None = None
 
     async def _find_mcu_port(self, *, log_missing: bool = True) -> str | None:
         mcu_ports = list(Path("/dev/serial/by-id/").glob("usb-Raspberry_Pi_Pico*"))
@@ -44,6 +45,7 @@ class SerialManager:
         writer = self.writer
         self.reader = None
         self.writer = None
+        self._mcu_protocol_config = None
         self.state.system_health.mcu_healthy = False
         if writer is not None:
             writer.close()
@@ -84,6 +86,7 @@ class SerialManager:
                     url=serial_port, baudrate=115200
                 )
                 self._connection_generation += 1
+                self._mcu_protocol_config = None
                 self.state.system_health.mcu_healthy = True
                 log_info("MCU initialized successfully.")
                 return True
@@ -148,6 +151,15 @@ class SerialManager:
     def connection_generation(self) -> int:
         """Monotonically increasing serial connection generation."""
         return self._connection_generation
+
+    @property
+    def mcu_protocol_config(self) -> tuple[str, int] | None:
+        """Protocol configuration most recently acknowledged by the MCU."""
+        return self._mcu_protocol_config
+
+    def record_mcu_protocol_config(self, protocol: str, dshot_speed: int) -> None:
+        """Record a protocol configuration reported by an MCU version packet."""
+        self._mcu_protocol_config = (protocol, dshot_speed)
 
     async def shutdown(self) -> None:
         """Shutdown the serial connection."""

--- a/src/rov_firmware/thrusters.py
+++ b/src/rov_firmware/thrusters.py
@@ -34,6 +34,10 @@ from .serial import SerialManager
 from .toast import ToastContent, cancel_thruster_test_action, toast_content
 
 
+_CONFIG_RETRY_INTERVAL_SECONDS = 0.5
+_CONFIG_ACK_WARNING_SECONDS = 5.0
+
+
 class Thrusters:
     """Thrusters control class."""
 
@@ -55,6 +59,11 @@ class Thrusters:
         self.regulator: Regulator = regulator
         self._last_sent_protocol_config: tuple[str, int] | None = None
         self._last_config_generation: int = -1
+        self._last_config_attempt_time: float = 0.0
+        self._pending_protocol_config: tuple[str, int] | None = None
+        self._pending_config_generation: int = -1
+        self._pending_config_since: float = 0.0
+        self._pending_config_warning_logged = False
 
         self.previous_direction_vector: NDArray[np.float32] = np.zeros(
             8, dtype=np.float32
@@ -516,20 +525,56 @@ class Thrusters:
         writer.write(packet)
         await writer.drain()
 
-    async def _ensure_config_sent(self, writer: StreamWriter) -> None:
+    async def _ensure_config_sent(self, writer: StreamWriter) -> bool:
         current = (
-            self.state.rov_config.thruster_protocol,
+            self.state.rov_config.thruster_protocol.value,
             self.state.rov_config.dshot_speed,
         )
         generation = self.serial_manager.connection_generation
+        if self.serial_manager.mcu_protocol_config == current:
+            self._pending_protocol_config = None
+            self._pending_config_generation = -1
+            self._pending_config_since = 0.0
+            self._pending_config_warning_logged = False
+            return True
+
+        # A protocol change is only safe while the Pico's last accepted motor
+        # command is neutral. Hold neutral until its version packet confirms
+        # the requested configuration, and retry if either packet was lost or
+        # rejected.
+        await self._send_packet(writer, [THRUSTER_NEUTRAL_PULSE_WIDTH] * NUM_MOTORS)
+
+        now = time.monotonic()
         if (
-            current == self._last_sent_protocol_config
-            and generation == self._last_config_generation
+            current != self._pending_protocol_config
+            or generation != self._pending_config_generation
         ):
-            return
-        await self._send_config_packet(writer)
-        self._last_sent_protocol_config = current
-        self._last_config_generation = generation
+            self._pending_protocol_config = current
+            self._pending_config_generation = generation
+            self._pending_config_since = now
+            self._pending_config_warning_logged = False
+        elif (
+            not self._pending_config_warning_logged
+            and now - self._pending_config_since >= _CONFIG_ACK_WARNING_SECONDS
+        ):
+            log_error(
+                "Thruster protocol change is still blocked because the MCU has not "
+                "confirmed it. Check power and telemetry for every ESC."
+            )
+            self._pending_config_warning_logged = True
+
+        should_retry = (
+            current != self._last_sent_protocol_config
+            or generation != self._last_config_generation
+            or now - self._last_config_attempt_time >= _CONFIG_RETRY_INTERVAL_SECONDS
+        )
+        if should_retry:
+            await self._send_config_packet(writer)
+            self._last_sent_protocol_config = current
+            self._last_config_generation = generation
+            self._last_config_attempt_time = now
+
+        return False
 
     def _determine_thrust_vector(
         self, current_time: float, last_send_time: float
@@ -592,10 +637,26 @@ class Thrusters:
                 next_tick = time.perf_counter() + interval
                 continue
             writer = self.serial_manager.get_writer()
-            await self._ensure_config_sent(writer)
+            try:
+                config_confirmed = await self._ensure_config_sent(writer)
+            except Exception as e:
+                await self.serial_manager.handle_connection_lost(
+                    f"Thruster protocol synchronization failed: {e}"
+                )
+                await asyncio.sleep(1)
+                next_tick = time.perf_counter() + interval
+                continue
+
+            if not config_confirmed:
+                sleep_time = next_tick - time.perf_counter()
+                await asyncio.sleep(max(0.0, sleep_time))
+                next_tick += interval
+                now = time.perf_counter()
+                if next_tick < now:
+                    next_tick = now + interval
+                continue
 
             current_time = time.time()
-            self.regulator.update_regulator_data_from_imu()
             new_thrust_vector, updated_last_send_time = self._determine_thrust_vector(
                 current_time, last_send_time
             )

--- a/src/rov_firmware/websocket/receive/config.py
+++ b/src/rov_firmware/websocket/receive/config.py
@@ -202,7 +202,13 @@ async def handle_import_config(
     old_ip = state.rov_config.ip_address
     old_websocket_port = state.rov_config.websocket_port
     previous_camera = state.rov_config.camera
-    raw = apply_migrations(dict(payload))
+    migration_input = dict(payload)
+    board_was_omitted = "mcuBoard" not in migration_input
+    if board_was_omitted:
+        migration_input["mcuBoard"] = state.rov_config.mcu_board.value
+    raw = apply_migrations(migration_input)
+    if board_was_omitted:
+        raw.pop("mcuBoard", None)
     _strip_device_reported(raw)
 
     current = state.rov_config.model_dump(by_alias=True)

--- a/src/rov_firmware/websocket/receive/config.py
+++ b/src/rov_firmware/websocket/receive/config.py
@@ -16,6 +16,7 @@ from ..queue import get_message_queue
 
 
 _DEVICE_REPORTED_FIELDS = ("firmwareVersion", "mcuFirmwareVersion")
+_APPLY_COMMAND_TIMEOUT_SECONDS = 10.0
 _SYSTEMCTL_TIMEOUT_SECONDS = 5.0
 
 
@@ -31,20 +32,30 @@ async def handle_get_config(
     log_info("Sent config to client.")
 
 
-def _apply_ip_address(ip_address: str) -> None:
-    path = shutil.which("manafish-network")
+def _run_apply_command(binary: str, success_message: str, failure_message: str) -> None:
+    """Run a bounded system configuration helper and report its result."""
+    path = shutil.which(binary)
     if path is None:
-        log_warn("manafish-network not found in PATH.")
+        log_warn(f"{binary} not found in PATH.")
         return
     try:
         subprocess.run(  # noqa: S603
             [path],
             check=True,
             capture_output=True,
+            timeout=_APPLY_COMMAND_TIMEOUT_SECONDS,
         )
-        log_info(f"Applied IP address change to {ip_address}.")
-    except subprocess.CalledProcessError:
-        log_warn(f"Failed to apply IP address change to {ip_address}.")
+        log_info(success_message)
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+        log_warn(f"{failure_message}: {error}")
+
+
+def _apply_ip_address(ip_address: str) -> None:
+    _run_apply_command(
+        "manafish-network",
+        f"Applied IP address change to {ip_address}.",
+        f"Failed to apply IP address change to {ip_address}",
+    )
 
 
 async def _restart_firmware() -> bool:
@@ -87,19 +98,11 @@ async def _restart_firmware() -> bool:
 
 
 def _apply_camera() -> None:
-    path = shutil.which("manafish-camera")
-    if path is None:
-        log_warn("manafish-camera not found in PATH.")
-        return
-    try:
-        subprocess.run(  # noqa: S603
-            [path],
-            check=True,
-            capture_output=True,
-        )
-        log_info("Applied camera settings and restarted the video stream.")
-    except subprocess.CalledProcessError:
-        log_warn("Failed to apply camera settings.")
+    _run_apply_command(
+        "manafish-camera",
+        "Applied camera settings and restarted the video stream.",
+        "Failed to apply camera settings",
+    )
 
 
 async def handle_set_config(
@@ -117,6 +120,12 @@ async def handle_set_config(
     previous_camera = state.rov_config.camera
     current_data = state.rov_config.model_dump(by_alias=False)
     update_data = payload.model_dump(by_alias=False, include=payload.model_fields_set)
+    if payload.camera is not None:
+        camera_update = payload.camera.model_dump(
+            by_alias=False,
+            include=payload.camera.model_fields_set,
+        )
+        update_data["camera"] = {**current_data["camera"], **camera_update}
     current_data.update(update_data)
     state.rov_config = RovConfig.model_validate(current_data)
     state.rov_config.save()
@@ -197,6 +206,8 @@ async def handle_import_config(
     _strip_device_reported(raw)
 
     current = state.rov_config.model_dump(by_alias=True)
+    if isinstance(raw.get("camera"), dict):
+        raw["camera"] = {**current["camera"], **raw["camera"]}
     merged = {**current, **raw}
 
     try:
@@ -209,6 +220,7 @@ async def handle_import_config(
     new_config.mcu_firmware_version = state.rov_config.mcu_firmware_version
     state.rov_config = new_config
     state.rov_config.save()
+    await get_message_queue().put(Config(payload=state.rov_config))
     log_info(
         f"Imported config from app. Skipped fields: {skipped or 'none'}.",
     )

--- a/src/rov_firmware/websocket/receive/config.py
+++ b/src/rov_firmware/websocket/receive/config.py
@@ -15,11 +15,7 @@ from ..message import Config
 from ..queue import get_message_queue
 
 
-_DEVICE_REPORTED_FIELDS = (
-    "firmwareVersion",
-    "configSchemaVersion",
-    "mcuFirmwareVersion",
-)
+_DEVICE_REPORTED_FIELDS = ("firmwareVersion", "mcuFirmwareVersion")
 _APPLY_COMMAND_TIMEOUT_SECONDS = 10.0
 _SYSTEMCTL_TIMEOUT_SECONDS = 5.0
 

--- a/src/rov_firmware/websocket/receive/config.py
+++ b/src/rov_firmware/websocket/receive/config.py
@@ -15,7 +15,11 @@ from ..message import Config
 from ..queue import get_message_queue
 
 
-_DEVICE_REPORTED_FIELDS = ("firmwareVersion", "mcuFirmwareVersion")
+_DEVICE_REPORTED_FIELDS = (
+    "firmwareVersion",
+    "configSchemaVersion",
+    "mcuFirmwareVersion",
+)
 _APPLY_COMMAND_TIMEOUT_SECONDS = 10.0
 _SYSTEMCTL_TIMEOUT_SECONDS = 5.0
 

--- a/src/tools/mock_websocket_server.py
+++ b/src/tools/mock_websocket_server.py
@@ -11,10 +11,12 @@ from typing import Any, cast
 import websockets
 from websockets import ServerConnection
 
+from rov_firmware.models.config import CURRENT_FIRMWARE_VERSION
+
 
 WEBSOCKET_PORT = 9000
 MOCK_CONFIG: dict[str, Any] = {
-    "firmwareVersion": "1.0.0",
+    "firmwareVersion": CURRENT_FIRMWARE_VERSION,
     "mcuFirmwareVersion": "",
     "rovName": "Manafish-m0ck",
     "mcuBoard": "pico",
@@ -106,6 +108,21 @@ THRUSTER_TEST_DURATION_SECONDS = 10
 AUTO_TUNING_OSCILLATION_DURATION_SECONDS = 10
 FLASH_DURATION_SECONDS = 3
 PERCENT_COMPLETE = 100
+
+
+def _update_mock_config(payload: dict[str, Any], *, imported: bool = False) -> None:
+    """Apply a partial config while preserving canonical mock-owned fields."""
+    update = dict(payload)
+    if imported:
+        update.pop("firmwareVersion", None)
+        update.pop("mcuFirmwareVersion", None)
+
+    camera = update.get("camera")
+    current_camera = MOCK_CONFIG.get("camera")
+    if isinstance(camera, dict) and isinstance(current_camera, dict):
+        update["camera"] = {**current_camera, **camera}
+
+    MOCK_CONFIG.update(update)
 
 
 async def _handle_client(websocket: ServerConnection) -> None:  # noqa: C901,PLR0912,PLR0915
@@ -492,7 +509,7 @@ async def _handle_client(websocket: ServerConnection) -> None:  # noqa: C901,PLR
                     await websocket.send(json.dumps(config_msg))
                 elif msg_type == "setConfig":
                     if isinstance(payload, dict):
-                        MOCK_CONFIG.update(cast(dict[str, Any], payload))
+                        _update_mock_config(cast(dict[str, Any], payload))
                     toast_msg = {
                         "type": "showToast",
                         "payload": {
@@ -509,10 +526,9 @@ async def _handle_client(websocket: ServerConnection) -> None:  # noqa: C901,PLR
                     await websocket.send(json.dumps(toast_msg))
                 elif msg_type == "importConfig":
                     if isinstance(payload, dict):
-                        raw = cast(dict[str, Any], dict(payload))
-                        raw.pop("firmwareVersion", None)
-                        raw.pop("mcuFirmwareVersion", None)
-                        MOCK_CONFIG.update(raw)
+                        _update_mock_config(
+                            cast(dict[str, Any], payload), imported=True
+                        )
                     config_msg = {"type": "config", "payload": MOCK_CONFIG}
                     await websocket.send(json.dumps(config_msg))
                     toast_msg = {

--- a/src/tools/mock_websocket_server.py
+++ b/src/tools/mock_websocket_server.py
@@ -56,7 +56,6 @@ MOCK_CONFIG: dict[str, Any] = {
         "regulatorLimit": 30,
         "minBatteryVoltage": 14.0,
         "maxBatteryVoltage": 21.5,
-        "internalResistance": 0.1,
     },
     "camera": {
         "width": 1440,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 import pytest
 
 from rov_firmware.models.config import (
+    CURRENT_CONFIG_SCHEMA_VERSION,
     CURRENT_FIRMWARE_VERSION,
     AxisConfig,
     Camera,
@@ -78,7 +79,7 @@ def test_power_rejects_non_positive_battery_voltage(voltage):
         )
 
 
-def test_1_1_6_migration_removes_internal_resistance_and_updates_old_depth_defaults():
+def test_schema_migration_removes_internal_resistance_and_updates_old_depth_defaults():
     raw = {
         "firmwareVersion": "1.1.5",
         "power": {"internalResistance": 0.1, "minBatteryVoltage": 16},
@@ -91,7 +92,8 @@ def test_1_1_6_migration_removes_internal_resistance_and_updates_old_depth_defau
 
     migrated = apply_migrations(raw)
 
-    assert migrated["firmwareVersion"] == "1.1.6"
+    assert migrated["firmwareVersion"] == "1.1.5"
+    assert migrated["configSchemaVersion"] == CURRENT_CONFIG_SCHEMA_VERSION
     assert migrated["power"] == {"minBatteryVoltage": 16}
     assert migrated["regulator"]["depth"] == {
         "kp": 2,
@@ -102,7 +104,7 @@ def test_1_1_6_migration_removes_internal_resistance_and_updates_old_depth_defau
     assert migrated["dshotSpeed"] == 600
 
 
-def test_1_1_6_migration_preserves_custom_depth_tuning():
+def test_schema_migration_preserves_custom_depth_tuning():
     custom_depth = {"kp": 3, "ki": 0.25, "kd": 0.75, "rate": 0.2}
     raw = {
         "firmwareVersion": "1.1.5",
@@ -112,6 +114,42 @@ def test_1_1_6_migration_preserves_custom_depth_tuning():
     migrated = apply_migrations(raw)
 
     assert migrated["regulator"]["depth"] == custom_depth
+
+
+def test_current_schema_does_not_reapply_settings_migration():
+    depth = {"kp": 6, "ki": 2, "kd": 0.6, "rate": 0.5}
+    raw = {
+        "firmwareVersion": "1.1.5",
+        "configSchemaVersion": CURRENT_CONFIG_SCHEMA_VERSION,
+        "regulator": {"depth": depth.copy()},
+    }
+
+    migrated = apply_migrations(raw)
+
+    assert migrated["regulator"]["depth"] == depth
+
+
+def test_load_persists_schema_migration(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(RovConfig, "_config_path", config_path)
+    raw = json.loads(RovConfig().model_dump_json(by_alias=True))
+    raw.pop("configSchemaVersion")
+    raw["power"]["internalResistance"] = 0.1
+    raw["regulator"]["depth"] = {
+        "kp": 6,
+        "ki": 2,
+        "kd": 0.6,
+        "rate": 0.5,
+    }
+    config_path.write_text(json.dumps(raw))
+
+    loaded = RovConfig.load()
+    saved = json.loads(config_path.read_text())
+
+    assert loaded.config_schema_version == CURRENT_CONFIG_SCHEMA_VERSION
+    assert loaded.regulator.depth.kp == pytest.approx(2)
+    assert saved["configSchemaVersion"] == CURRENT_CONFIG_SCHEMA_VERSION
+    assert "internalResistance" not in saved["power"]
 
 
 @pytest.mark.parametrize("dshot_speed", [150, 300, 600])
@@ -163,6 +201,7 @@ def test_rov_config_json_round_trip_uses_camel_case_aliases():
     serialized = json.loads(config.model_dump_json(by_alias=True))
 
     assert "firmwareVersion" in serialized
+    assert serialized["configSchemaVersion"] == CURRENT_CONFIG_SCHEMA_VERSION
     assert "mcuFirmwareVersion" in serialized
     assert "dshotSpeed" in serialized
     assert "ipAddress" in serialized

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,10 +8,12 @@ from rov_firmware.models.config import (
     CURRENT_FIRMWARE_VERSION,
     AxisConfig,
     Camera,
+    McuBoard,
     PartialRovConfig,
     Power,
     RovConfig,
     ThrusterPinSetup,
+    apply_migrations,
     compare_semver,
     parse_semver,
 )
@@ -51,19 +53,17 @@ def test_axis_config_accepts_float_values():
     assert axis.rate == pytest.approx(2.0)
 
 
-def test_power_validators_accept_positive_voltage_and_zero_resistance():
+def test_power_validators_accept_positive_voltage():
     power = Power(
         thrusters_limit=30,
         actions_limit=40,
         regulator_limit=50,
         min_battery_voltage=14.0,
         max_battery_voltage=21.5,
-        internal_resistance=0.0,
     )
 
     assert power.min_battery_voltage == pytest.approx(14.0)
     assert power.max_battery_voltage == pytest.approx(21.5)
-    assert power.internal_resistance == pytest.approx(0.0)
 
 
 @pytest.mark.parametrize("voltage", [0.0, -1.0])
@@ -75,27 +75,61 @@ def test_power_rejects_non_positive_battery_voltage(voltage):
             regulator_limit=50,
             min_battery_voltage=voltage,
             max_battery_voltage=21.5,
-            internal_resistance=0.1,
         )
 
 
-def test_power_rejects_negative_internal_resistance():
-    with pytest.raises(ValidationError):
-        Power(
-            thrusters_limit=30,
-            actions_limit=40,
-            regulator_limit=50,
-            min_battery_voltage=14.0,
-            max_battery_voltage=21.5,
-            internal_resistance=-0.01,
-        )
+def test_1_1_6_migration_removes_internal_resistance_and_updates_old_depth_defaults():
+    raw = {
+        "firmwareVersion": "1.1.5",
+        "power": {"internalResistance": 0.1, "minBatteryVoltage": 16},
+        "regulator": {
+            "depth": {"kp": 6, "ki": 2, "kd": 0.6, "rate": 0.5},
+        },
+        "mcuBoard": "pico",
+        "dshotSpeed": 1200,
+    }
+
+    migrated = apply_migrations(raw)
+
+    assert migrated["firmwareVersion"] == "1.1.6"
+    assert migrated["power"] == {"minBatteryVoltage": 16}
+    assert migrated["regulator"]["depth"] == {
+        "kp": 2,
+        "ki": 0,
+        "kd": 0.5,
+        "rate": 0.5,
+    }
+    assert migrated["dshotSpeed"] == 600
 
 
-@pytest.mark.parametrize("dshot_speed", [150, 300, 600, 1200])
+def test_1_1_6_migration_preserves_custom_depth_tuning():
+    custom_depth = {"kp": 3, "ki": 0.25, "kd": 0.75, "rate": 0.2}
+    raw = {
+        "firmwareVersion": "1.1.5",
+        "regulator": {"depth": custom_depth.copy()},
+    }
+
+    migrated = apply_migrations(raw)
+
+    assert migrated["regulator"]["depth"] == custom_depth
+
+
+@pytest.mark.parametrize("dshot_speed", [150, 300, 600])
 def test_rov_config_accepts_supported_dshot_speeds(dshot_speed):
     config = RovConfig(dshot_speed=dshot_speed)
 
     assert config.dshot_speed == dshot_speed
+
+
+def test_rov_config_rejects_dshot_1200_for_pico():
+    with pytest.raises(ValidationError, match="DShot1200 requires Pico 2"):
+        RovConfig(mcu_board=McuBoard.PICO, dshot_speed=1200)
+
+
+def test_rov_config_accepts_dshot_1200_for_pico2():
+    config = RovConfig(mcu_board=McuBoard.PICO2, dshot_speed=1200)
+
+    assert config.dshot_speed == 1200
 
 
 @pytest.mark.parametrize("dshot_speed", [0, 100, 450, 2400])
@@ -181,6 +215,9 @@ def test_rov_config_defaults_are_sensible():
     assert config.websocket_port == 9000
     assert config.dshot_speed == 300
     assert config.thruster_protocol == "dshot"
+    assert config.regulator.depth.kp == pytest.approx(2.0)
+    assert config.regulator.depth.ki == pytest.approx(0.0)
+    assert config.regulator.depth.kd == pytest.approx(0.5)
 
 
 _NULLSPACE_VECTORS = [
@@ -372,3 +409,16 @@ def test_partial_rov_config_accepts_camera_update():
 
     assert partial.camera is not None
     assert partial.camera.framerate == 24
+
+
+@pytest.mark.parametrize(
+    "camera_update",
+    [
+        {"framerate": None},
+        {"keyframeInterval": None},
+        {"cropFov": None, "bitrate": 8_000_000},
+    ],
+)
+def test_partial_rov_config_rejects_explicit_null_camera_fields(camera_update):
+    with pytest.raises(ValidationError, match="Camera fields cannot be null"):
+        PartialRovConfig.model_validate({"camera": camera_update})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,6 @@ from pydantic import ValidationError
 import pytest
 
 from rov_firmware.models.config import (
-    CURRENT_CONFIG_SCHEMA_VERSION,
     CURRENT_FIRMWARE_VERSION,
     AxisConfig,
     Camera,
@@ -79,7 +78,7 @@ def test_power_rejects_non_positive_battery_voltage(voltage):
         )
 
 
-def test_schema_migration_removes_internal_resistance_and_updates_old_depth_defaults():
+def test_1_1_6_migration_removes_internal_resistance_and_updates_old_depth_defaults():
     raw = {
         "firmwareVersion": "1.1.5",
         "power": {"internalResistance": 0.1, "minBatteryVoltage": 16},
@@ -92,8 +91,7 @@ def test_schema_migration_removes_internal_resistance_and_updates_old_depth_defa
 
     migrated = apply_migrations(raw)
 
-    assert migrated["firmwareVersion"] == "1.1.5"
-    assert migrated["configSchemaVersion"] == CURRENT_CONFIG_SCHEMA_VERSION
+    assert migrated["firmwareVersion"] == "1.1.6"
     assert migrated["power"] == {"minBatteryVoltage": 16}
     assert migrated["regulator"]["depth"] == {
         "kp": 2,
@@ -104,7 +102,7 @@ def test_schema_migration_removes_internal_resistance_and_updates_old_depth_defa
     assert migrated["dshotSpeed"] == 600
 
 
-def test_schema_migration_preserves_custom_depth_tuning():
+def test_1_1_6_migration_preserves_custom_depth_tuning():
     custom_depth = {"kp": 3, "ki": 0.25, "kd": 0.75, "rate": 0.2}
     raw = {
         "firmwareVersion": "1.1.5",
@@ -114,42 +112,6 @@ def test_schema_migration_preserves_custom_depth_tuning():
     migrated = apply_migrations(raw)
 
     assert migrated["regulator"]["depth"] == custom_depth
-
-
-def test_current_schema_does_not_reapply_settings_migration():
-    depth = {"kp": 6, "ki": 2, "kd": 0.6, "rate": 0.5}
-    raw = {
-        "firmwareVersion": "1.1.5",
-        "configSchemaVersion": CURRENT_CONFIG_SCHEMA_VERSION,
-        "regulator": {"depth": depth.copy()},
-    }
-
-    migrated = apply_migrations(raw)
-
-    assert migrated["regulator"]["depth"] == depth
-
-
-def test_load_persists_schema_migration(monkeypatch, tmp_path):
-    config_path = tmp_path / "config.json"
-    monkeypatch.setattr(RovConfig, "_config_path", config_path)
-    raw = json.loads(RovConfig().model_dump_json(by_alias=True))
-    raw.pop("configSchemaVersion")
-    raw["power"]["internalResistance"] = 0.1
-    raw["regulator"]["depth"] = {
-        "kp": 6,
-        "ki": 2,
-        "kd": 0.6,
-        "rate": 0.5,
-    }
-    config_path.write_text(json.dumps(raw))
-
-    loaded = RovConfig.load()
-    saved = json.loads(config_path.read_text())
-
-    assert loaded.config_schema_version == CURRENT_CONFIG_SCHEMA_VERSION
-    assert loaded.regulator.depth.kp == pytest.approx(2)
-    assert saved["configSchemaVersion"] == CURRENT_CONFIG_SCHEMA_VERSION
-    assert "internalResistance" not in saved["power"]
 
 
 @pytest.mark.parametrize("dshot_speed", [150, 300, 600])
@@ -201,7 +163,6 @@ def test_rov_config_json_round_trip_uses_camel_case_aliases():
     serialized = json.loads(config.model_dump_json(by_alias=True))
 
     assert "firmwareVersion" in serialized
-    assert serialized["configSchemaVersion"] == CURRENT_CONFIG_SCHEMA_VERSION
     assert "mcuFirmwareVersion" in serialized
     assert "dshotSpeed" in serialized
     assert "ipAddress" in serialized

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,9 @@ from rov_firmware.models.config import (
         ("1.0", (1, 0, 0)),
         ("", (0, 0, 0)),
         ("abc", (0, 0, 0)),
+        (None, (0, 0, 0)),
+        (123, (0, 0, 0)),
+        ({"major": 1}, (0, 0, 0)),
     ],
 )
 def test_parse_semver(version, expected):

--- a/tests/test_import_config.py
+++ b/tests/test_import_config.py
@@ -78,6 +78,18 @@ def test_import_keeps_current_values_for_fields_not_in_payload(rov_state):
     assert rov_state.rov_config.smoothing_factor == pytest.approx(0.7)
 
 
+def test_import_merges_partial_camera_with_current_values(rov_state, monkeypatch):
+    rov_state.rov_config.camera.width = 1280
+    rov_state.rov_config.camera.bitrate = 8_000_000
+    monkeypatch.setattr(config_handlers, "_apply_camera", lambda: None)
+
+    asyncio.run(handle_import_config(rov_state, {"camera": {"framerate": 24}}))
+
+    assert rov_state.rov_config.camera.framerate == 24
+    assert rov_state.rov_config.camera.width == 1280
+    assert rov_state.rov_config.camera.bitrate == 8_000_000
+
+
 def test_import_persists_to_disk(rov_state, isolated_config_path):
     payload = _baseline_export(rov_state)
     payload["rovName"] = "Persisted"
@@ -86,6 +98,16 @@ def test_import_persists_to_disk(rov_state, isolated_config_path):
 
     assert isolated_config_path.exists()
     assert "Persisted" in isolated_config_path.read_text()
+
+
+def test_import_publishes_canonical_config_to_client(rov_state, monkeypatch):
+    queue = asyncio.Queue()
+    monkeypatch.setattr(config_handlers, "get_message_queue", lambda: queue)
+
+    asyncio.run(handle_import_config(rov_state, {"rovName": "Published"}))
+
+    message = queue.get_nowait()
+    assert message.payload.rov_name == "Published"
 
 
 def test_import_restarts_firmware_when_websocket_port_changed(rov_state, monkeypatch):

--- a/tests/test_import_config.py
+++ b/tests/test_import_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from rov_firmware.models.config import RovConfig
+from rov_firmware.models.config import McuBoard, RovConfig
 from rov_firmware.websocket.receive import config as config_handlers
 from rov_firmware.websocket.receive.config import handle_import_config
 
@@ -76,6 +76,35 @@ def test_import_keeps_current_values_for_fields_not_in_payload(rov_state):
 
     assert rov_state.rov_config.rov_name == "MinimalImport"
     assert rov_state.rov_config.smoothing_factor == pytest.approx(0.7)
+
+
+def test_partial_old_import_uses_current_pico2_for_dshot_1200_migration(rov_state):
+    rov_state.rov_config.mcu_board = McuBoard.PICO2
+
+    asyncio.run(
+        handle_import_config(
+            rov_state,
+            {"firmwareVersion": "1.1.5", "dshotSpeed": 1200},
+        )
+    )
+
+    assert rov_state.rov_config.mcu_board is McuBoard.PICO2
+    assert rov_state.rov_config.dshot_speed == 1200
+
+
+def test_import_with_malformed_version_still_applies_migrations(rov_state):
+    asyncio.run(
+        handle_import_config(
+            rov_state,
+            {
+                "firmwareVersion": None,
+                "power": {"internalResistance": 0.1},
+                "rovName": "Migrated",
+            },
+        )
+    )
+
+    assert rov_state.rov_config.rov_name == "Migrated"
 
 
 def test_import_merges_partial_camera_with_current_values(rov_state, monkeypatch):

--- a/tests/test_import_config.py
+++ b/tests/test_import_config.py
@@ -35,12 +35,14 @@ def test_import_preserves_device_reported_fields(rov_state):
 
     payload = _baseline_export(rov_state)
     payload["firmwareVersion"] = "spoofed"
+    payload["configSchemaVersion"] = 0
     payload["mcuFirmwareVersion"] = "spoofed"
     payload["rovName"] = "X"
 
     asyncio.run(handle_import_config(rov_state, payload))
 
     assert rov_state.rov_config.firmware_version != "spoofed"
+    assert rov_state.rov_config.config_schema_version > 0
     assert rov_state.rov_config.mcu_firmware_version == "real-mcu-version"
     assert rov_state.rov_config.rov_name == "X"
 

--- a/tests/test_import_config.py
+++ b/tests/test_import_config.py
@@ -35,14 +35,12 @@ def test_import_preserves_device_reported_fields(rov_state):
 
     payload = _baseline_export(rov_state)
     payload["firmwareVersion"] = "spoofed"
-    payload["configSchemaVersion"] = 0
     payload["mcuFirmwareVersion"] = "spoofed"
     payload["rovName"] = "X"
 
     asyncio.run(handle_import_config(rov_state, payload))
 
     assert rov_state.rov_config.firmware_version != "spoofed"
-    assert rov_state.rov_config.config_schema_version > 0
     assert rov_state.rov_config.mcu_firmware_version == "real-mcu-version"
     assert rov_state.rov_config.rov_name == "X"
 

--- a/tests/test_mcu_sensor.py
+++ b/tests/test_mcu_sensor.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from rov_firmware.constants import MCU_PROTOCOL_DSHOT, MCU_VERSION_START_BYTE
+from rov_firmware.models.config import ThrusterProtocol
+from rov_firmware.sensors import mcu as mcu_module
+from rov_firmware.sensors.mcu import McuSensor
+from rov_firmware.serial import SerialManager
+
+
+def _version_packet(protocol: int, dshot_speed: int) -> bytes:
+    packet = bytearray(
+        [
+            MCU_VERSION_START_BYTE,
+            1,
+            2,
+            3,
+            protocol,
+            dshot_speed & 0xFF,
+            dshot_speed >> 8,
+        ]
+    )
+    checksum = 0
+    for value in packet:
+        checksum ^= value
+    packet.append(checksum)
+    return bytes(packet)
+
+
+def test_version_packet_acknowledges_mcu_without_reverting_requested_config(
+    rov_state, monkeypatch
+):
+    queue = asyncio.Queue()
+    monkeypatch.setattr(mcu_module, "get_message_queue", lambda: queue)
+    rov_state.rov_config.thruster_protocol = ThrusterProtocol.PWM
+    rov_state.rov_config.dshot_speed = 300
+    serial_manager = SerialManager(rov_state)
+    sensor = McuSensor(rov_state, serial_manager)
+    monkeypatch.setattr(sensor, "_get_expected_version", lambda: "1.2.3")
+
+    sensor._handle_version_packet(_version_packet(MCU_PROTOCOL_DSHOT, 600))
+
+    assert serial_manager.mcu_protocol_config == ("dshot", 600)
+    assert rov_state.rov_config.thruster_protocol == ThrusterProtocol.PWM
+    assert rov_state.rov_config.dshot_speed == 300
+    assert queue.get_nowait().payload.thruster_protocol == ThrusterProtocol.PWM

--- a/tests/test_regulator.py
+++ b/tests/test_regulator.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import numpy as np
 import pytest
 from scipy.spatial.transform import Rotation
@@ -91,6 +93,25 @@ def test_mahony_quaternion_stays_normalized_after_many_updates():
         ahrs.update(gyro.copy(), accel, 1 / THRUSTER_SEND_FREQUENCY)
 
     assert np.linalg.norm(ahrs.current_attitude.as_quat()) == pytest.approx(1.0)
+
+
+def test_imu_update_loop_does_not_depend_on_mcu_connection(rov_state, monkeypatch):
+    regulator = RegulatorController(rov_state)
+    updates: list[None] = []
+
+    def update_once() -> None:
+        updates.append(None)
+
+    async def cancel_after_first_tick(_delay: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(regulator, "update_regulator_data_from_imu", update_once)
+    monkeypatch.setattr(asyncio, "sleep", cancel_after_first_tick)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(regulator.imu_update_loop())
+
+    assert updates == [None]
 
 
 def test_handle_depth_hold_computes_pid(rov_state):

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -1,5 +1,6 @@
 import asyncio
 from pathlib import Path
+import subprocess
 
 import numpy as np
 import pytest
@@ -83,6 +84,45 @@ def test_set_config_applies_camera_only_when_camera_changed(rov_state, monkeypat
     camera_payload = PartialRovConfig.model_validate({"camera": {"framerate": 24}})
     asyncio.run(handle_set_config(rov_state, camera_payload))
     assert apply_calls == [None]
+
+
+def test_set_config_preserves_unspecified_camera_fields(rov_state, monkeypatch):
+    rov_state.rov_config.camera.width = 1280
+    rov_state.rov_config.camera.bitrate = 8_000_000
+    monkeypatch.setattr(config_handlers, "_apply_camera", lambda: None)
+
+    payload = PartialRovConfig.model_validate({"camera": {"framerate": 24}})
+    asyncio.run(handle_set_config(rov_state, payload))
+
+    assert rov_state.rov_config.camera.framerate == 24
+    assert rov_state.rov_config.camera.width == 1280
+    assert rov_state.rov_config.camera.bitrate == 8_000_000
+
+
+def test_apply_command_has_a_timeout(monkeypatch):
+    calls: list[dict] = []
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        config_handlers.shutil, "which", lambda binary: f"/bin/{binary}"
+    )
+
+    def run(*args, **kwargs):
+        calls.append(kwargs)
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(config_handlers.subprocess, "run", run)
+    monkeypatch.setattr(config_handlers, "log_warn", warnings.append)
+
+    config_handlers._apply_camera()
+
+    assert calls == [
+        {
+            "check": True,
+            "capture_output": True,
+            "timeout": config_handlers._APPLY_COMMAND_TIMEOUT_SECONDS,
+        }
+    ]
+    assert warnings and warnings[0].startswith("Failed to apply camera settings:")
 
 
 def test_set_config_restarts_firmware_when_websocket_port_changed(

--- a/tests/test_thrusters.py
+++ b/tests/test_thrusters.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
+from rov_firmware import thrusters as thrusters_module
 from rov_firmware.constants import (
     MCU_CONFIG_START_BYTE,
     MCU_PROTOCOL_DSHOT,
@@ -31,6 +32,11 @@ class _WriterSpy:
 
     async def drain(self):
         self.drains += 1
+
+
+class _SerialManagerSpy:
+    connection_generation = 1
+    mcu_protocol_config: tuple[str, int] | None = None
 
 
 @pytest.fixture
@@ -275,3 +281,75 @@ def test_send_config_packet_writes_expected_binary_packet(
 
     assert writer.writes == [bytes(expected)]
     assert writer.drains == 1
+
+
+def test_protocol_config_holds_neutral_until_mcu_acknowledges(rov_state):
+    serial_manager = _SerialManagerSpy()
+    thrusters = Thrusters(
+        rov_state,
+        cast(Any, serial_manager),
+        cast(Any, RegulatorController(rov_state)),
+    )
+    writer = _WriterSpy()
+
+    confirmed = asyncio.run(thrusters._ensure_config_sent(cast(Any, writer)))
+
+    neutral_payload = struct.pack(
+        f"<{NUM_MOTORS}H", *([THRUSTER_NEUTRAL_PULSE_WIDTH] * NUM_MOTORS)
+    )
+    assert confirmed is False
+    assert writer.writes[0][1:-1] == neutral_payload
+    assert writer.writes[1][0] == MCU_CONFIG_START_BYTE
+
+    serial_manager.mcu_protocol_config = ("dshot", 300)
+    writer.writes.clear()
+
+    confirmed = asyncio.run(thrusters._ensure_config_sent(cast(Any, writer)))
+
+    assert confirmed is True
+    assert writer.writes == []
+
+
+def test_protocol_config_retries_after_unacknowledged_attempt(rov_state):
+    serial_manager = _SerialManagerSpy()
+    thrusters = Thrusters(
+        rov_state,
+        cast(Any, serial_manager),
+        cast(Any, RegulatorController(rov_state)),
+    )
+    writer = _WriterSpy()
+
+    asyncio.run(thrusters._ensure_config_sent(cast(Any, writer)))
+    thrusters._last_config_attempt_time -= 1
+    writer.writes.clear()
+
+    confirmed = asyncio.run(thrusters._ensure_config_sent(cast(Any, writer)))
+
+    assert confirmed is False
+    assert len(writer.writes) == 2
+    assert writer.writes[0][0] == THRUSTER_INPUT_START_BYTE
+    assert writer.writes[1][0] == MCU_CONFIG_START_BYTE
+
+
+def test_protocol_config_logs_actionable_error_when_ack_stays_blocked(
+    rov_state, monkeypatch
+):
+    serial_manager = _SerialManagerSpy()
+    thrusters = Thrusters(
+        rov_state,
+        cast(Any, serial_manager),
+        cast(Any, RegulatorController(rov_state)),
+    )
+    writer = _WriterSpy()
+    messages: list[str] = []
+    monkeypatch.setattr(thrusters_module, "log_error", messages.append)
+
+    asyncio.run(thrusters._ensure_config_sent(cast(Any, writer)))
+    thrusters._pending_config_since -= 6
+    asyncio.run(thrusters._ensure_config_sent(cast(Any, writer)))
+    asyncio.run(thrusters._ensure_config_sent(cast(Any, writer)))
+
+    assert messages == [
+        "Thruster protocol change is still blocked because the MCU has not "
+        "confirmed it. Check power and telemetry for every ESC."
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -109,7 +109,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/56/33/26ec2e8049eaa2f07
 
 [[package]]
 name = "manafish"
-version = "1.1.6"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "bmi270" },

--- a/uv.lock
+++ b/uv.lock
@@ -109,7 +109,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/56/33/26ec2e8049eaa2f07
 
 [[package]]
 name = "manafish"
-version = "1.1.5"
+version = "1.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "bmi270" },


### PR DESCRIPTION
## Summary

- bump firmware to 1.1.6 and migrate persisted settings based on the firmware version
- remove battery resistance, update depth-hold defaults, and migrate unsupported Pico DShot1200 configurations
- keep IMU updates running without a connected Pico and correct AM32 telemetry scaling/current sensing
- coordinate neutral output, configuration retries, version acknowledgement, and per-motor telemetry timeouts with the MCU
- publish canonical imported configuration back to clients and preserve partial camera settings safely
- harden camera/network apply helpers and document current desktop and Android networking behavior

## Validation

- uv run ruff format --check .
- uv run ruff check .
- uv run ty check
- uv run pytest (127 tests)
- nix fmt -- --ci
- nix flake check --no-build

## MCU release dependency

Pinned the published MCU v1.0.3-rc.1 Pico and Pico 2 artifacts by exact release URL and Nix hash. The full validation suite was rerun with those artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partial camera configuration updates without overwriting unspecified settings.
  * Improved Ethernet setup guidance, including static addressing, DHCP, USB-C adapters, and desktop connectivity.
  * Added more reliable attitude updates and safer thruster startup behavior while awaiting controller confirmation.

* **Bug Fixes**
  * Camera streaming now handles odd image dimensions correctly.
  * Improved configuration imports, migrations, validation, and timeout handling.
  * Updated Pico firmware support to version 1.1.6 and applied related settings updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->