### PR TITLE
fix(networking): disable onboard wireless radios

### DIFF
--- a/nix/networking.nix
+++ b/nix/networking.nix
@@ -68,6 +68,18 @@
     ${systemctl} try-restart --no-block manafish-firmware.service
   '';
 in {
+  # Keep the onboard radios powered down; the ROV communicates over Ethernet.
+  hardware.raspberry-pi.config.all.dt-overlays = {
+    disable-wifi = {
+      enable = true;
+      params = {};
+    };
+    disable-bt = {
+      enable = true;
+      params = {};
+    };
+  };
+
   networking = {
     hostName = "manafish";
     usePredictableInterfaceNames = false;


### PR DESCRIPTION
## Summary

- disable the Raspberry Pi 3 onboard Wi-Fi radio at boot
- disable the onboard Bluetooth radio at boot
- retain Ethernet networking as the ROV control path

## Verification

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` (127 passed)
- `nix fmt -- --ci`
- `nix flake check --no-build`
- verified generated `config.txt` contains `dtoverlay=disable-wifi` and `dtoverlay=disable-bt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration to disable onboard Wi‑Fi and Bluetooth radios on Raspberry Pi devices.
  * Ethernet networking remains enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->