### PR TITLE
fix(firmware): address RC field regressions

### DIFF
--- a/nix/camera.nix
+++ b/nix/camera.nix
@@ -203,6 +203,9 @@ in {
     };
   };
 
+  # Camera config changes are applied by the firmware service at runtime.
+  systemd.services.manafish-firmware.path = [cameraApply];
+
   services.go2rtc = {
     enable = true;
     settings = {

--- a/nix/networking.nix
+++ b/nix/networking.nix
@@ -169,6 +169,9 @@ in {
     };
   };
 
+  # The WebSocket config handler runs inside this restricted service.
+  systemd.services.manafish-firmware.path = [networkScript];
+
   systemd.services.dnsmasq = {
     after = ["manafish-network.service"];
     requires = ["manafish-network.service"];

--- a/nix/system.nix
+++ b/nix/system.nix
@@ -58,6 +58,7 @@ in {
       mkdir -p "$MCU_DIR"
       for board in pico pico2; do
         TARGET="$MCU_DIR/$board-${mcuFirmwareVersion}.uf2"
+        find "$MCU_DIR" -maxdepth 1 -type f -name "$board-v*.uf2" ! -name "$(basename "$TARGET")" -delete
         [ -f "$TARGET" ] && continue
         case "$board" in
           pico)  cp ${inputs.mcu-firmware-pico} "$TARGET" ;;

--- a/src/rov_firmware/models/config.py
+++ b/src/rov_firmware/models/config.py
@@ -1,8 +1,10 @@
 """Configuration models for the ROV firmware."""
 
 from enum import StrEnum
+from ipaddress import IPv4Address, IPv4Network
 import json
 from pathlib import Path
+import re
 import secrets
 import tempfile
 import tomllib
@@ -28,28 +30,60 @@ with _pyproject_path.open("rb") as _f:
     _pyproject = tomllib.load(_f)
 CURRENT_FIRMWARE_VERSION = _pyproject["project"]["version"]
 
-_MAJOR = 0
-_MINOR = 1
-_PATCH = 2
 _DSHOT_1200 = 1200
 _PICO_SAFE_DSHOT_SPEED = 600
+_MIN_TCP_PORT = 1
+_MAX_TCP_PORT = 65535
+_SEMVER_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$"
+)
 
 
 def parse_semver(version: object) -> tuple[int, int, int]:
     """Parse semver string into (major, minor, patch) tuple."""
     if not isinstance(version, str):
         return (0, 0, 0)
-    parts = version.split(".")
-    major = int(parts[_MAJOR]) if len(parts) > _MAJOR and parts[_MAJOR].isdigit() else 0
-    minor = int(parts[_MINOR]) if len(parts) > _MINOR and parts[_MINOR].isdigit() else 0
-    patch = int(parts[_PATCH]) if len(parts) > _PATCH and parts[_PATCH].isdigit() else 0
-    return (major, minor, patch)
+    match = _SEMVER_RE.fullmatch(version)
+    if match is None:
+        return (0, 0, 0)
+    return (
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+    )
+
+
+def _semver_sort_key(
+    version: object,
+) -> tuple[int, int, int, int, tuple[tuple[int, int, str], ...]]:
+    if not isinstance(version, str):
+        return (0, 0, 0, 0, ())
+    match = _SEMVER_RE.fullmatch(version)
+    if match is None:
+        return (0, 0, 0, 0, ())
+
+    prerelease = match.group("prerelease")
+    prerelease_key: tuple[tuple[int, int, str], ...] = ()
+    if prerelease is not None:
+        prerelease_key = tuple(
+            (0, int(identifier), "") if identifier.isdigit() else (1, 0, identifier)
+            for identifier in prerelease.split(".")
+        )
+    major, minor, patch = parse_semver(version)
+    return (
+        major,
+        minor,
+        patch,
+        1 if prerelease is None else 0,
+        prerelease_key,
+    )
 
 
 def compare_semver(a: object, b: object) -> int:
     """Compare two semver strings. Returns -1, 0, or 1."""
-    a_tuple = parse_semver(a)
-    b_tuple = parse_semver(b)
+    a_tuple = _semver_sort_key(a)
+    b_tuple = _semver_sort_key(b)
     if a_tuple < b_tuple:
         return -1
     elif a_tuple > b_tuple:
@@ -65,7 +99,7 @@ def apply_migrations(raw: dict[str, Any]) -> dict[str, Any]:
         raw.setdefault("nullspaceVectors", [])
         raw["firmwareVersion"] = "1.1.0"
 
-    if compare_semver(firmware_version, "1.1.6") == -1:
+    if compare_semver(firmware_version, "1.1.6-rc.1") == -1:
         power = raw.get("power")
         if isinstance(power, dict):
             power.pop("internalResistance", None)
@@ -90,7 +124,7 @@ def apply_migrations(raw: dict[str, Any]) -> dict[str, Any]:
         ):
             raw["dshotSpeed"] = _PICO_SAFE_DSHOT_SPEED
 
-        raw["firmwareVersion"] = "1.1.6"
+        raw["firmwareVersion"] = "1.1.6-rc.1"
 
     return raw
 
@@ -473,6 +507,31 @@ class RovConfig(CamelCaseModel):
     camera: Camera = Camera()
     ip_address: str = "10.10.10.10"
     websocket_port: int = 9000
+
+    @field_validator("ip_address", mode="after")
+    @classmethod
+    def validate_ip_address(cls, v: str) -> str:
+        """Require a usable IPv4 host address for the ROV's /24 network."""
+        try:
+            address = IPv4Address(v)
+        except ValueError as error:
+            msg = "ROV IP address must be a valid IPv4 address"
+            raise ValueError(msg) from error
+
+        network = IPv4Network(f"{address}/24", strict=False)
+        if address in (network.network_address, network.broadcast_address):
+            msg = "ROV IP address must be a usable /24 host address"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("websocket_port", mode="after")
+    @classmethod
+    def validate_websocket_port(cls, v: int) -> int:
+        """Require a valid TCP port for the WebSocket server."""
+        if not _MIN_TCP_PORT <= v <= _MAX_TCP_PORT:
+            msg = "WebSocket port must be between 1 and 65535"
+            raise ValueError(msg)
+        return v
 
     @field_validator("dshot_speed", mode="after")
     @classmethod

--- a/src/rov_firmware/rov_state.py
+++ b/src/rov_firmware/rov_state.py
@@ -1,5 +1,7 @@
 """Central state management for the ROV firmware."""
 
+import asyncio
+
 from .models.config import RovConfig
 from .models.regulator import RegulatorData
 from .models.sensors import ImuData, McuData, PressureData
@@ -21,3 +23,4 @@ class RovState:
         self.regulator: RegulatorData = RegulatorData()
         self.thrusters: ThrusterData = ThrusterData()
         self.mcu_flashing: bool = False
+        self.mcu_flash_lock = asyncio.Lock()

--- a/src/rov_firmware/sensors/mcu.py
+++ b/src/rov_firmware/sensors/mcu.py
@@ -35,7 +35,11 @@ from ..rov_state import RovState
 from ..serial import SerialManager
 from ..websocket.message import Config
 from ..websocket.queue import get_message_queue
-from ..websocket.receive.mcu import flash_mcu_firmware, resolve_mcu_firmware
+from ..websocket.receive.mcu import (
+    flash_mcu_firmware,
+    mcu_update_required,
+    resolve_mcu_firmware,
+)
 
 
 _MAX_READ_BUFFER_SIZE = 512
@@ -45,6 +49,7 @@ _TELEMETRY_START_TOKEN = bytes((MCU_TELEMETRY_START_BYTE,))
 _TELEMETRY_BATCH_START_TOKEN = bytes((MCU_TELEMETRY_BATCH_START_BYTE,))
 _LOG_PACKET_START_TOKEN = bytes((LOG_PACKET_START_BYTE,))
 _VERSION_PACKET_START_TOKEN = bytes((MCU_VERSION_START_BYTE,))
+_TELEMETRY_FIELDS = ("erpm", "voltage", "temperature", "current", "signal_quality")
 
 _LOG_LEVEL_MAP: dict[int, LogLevel] = {
     LOG_LEVEL_INFO: LogLevel.INFO,
@@ -71,8 +76,11 @@ class McuSensor:
         """
         self.state: RovState = state
         self.serial_manager: SerialManager = serial_manager
-        self._last_telemetry_time: list[float] = [0.0] * NUM_MOTORS
+        self._last_telemetry_time: list[list[float]] = [
+            [0.0] * len(_TELEMETRY_FIELDS) for _ in range(NUM_MOTORS)
+        ]
         self._startup_time: float = time.monotonic()
+        self._flash_task: asyncio.Task[None] | None = None
 
     async def read_loop(self) -> None:
         """Read telemetry data from the MCU in a loop."""
@@ -321,10 +329,17 @@ class McuSensor:
         if expected_version is None:
             return
 
-        if current_version == expected_version:
+        if not mcu_update_required(
+            self.state.rov_config.mcu_board,
+            current_version,
+            expected_version,
+        ):
             return
 
         if self.state.mcu_flashing:
+            return
+
+        if self._flash_task is not None and not self._flash_task.done():
             return
 
         if time.monotonic() - self._startup_time > MCU_AUTO_UPDATE_WINDOW_S:
@@ -337,7 +352,7 @@ class McuSensor:
         log_warn(
             f"MCU firmware mismatch: current is {current_version}, expected is {expected_version}. Auto-flashing."
         )
-        _ = asyncio.get_running_loop().create_task(self._flash_mcu())
+        self._flash_task = asyncio.get_running_loop().create_task(self._flash_mcu())
 
     async def _flash_mcu(self) -> None:
         succeeded = await flash_mcu_firmware(
@@ -350,26 +365,20 @@ class McuSensor:
 
     def _reset_telemetry(self) -> None:
         for i in range(NUM_MOTORS):
-            self.state.mcu_telemetry.erpm[i] = 0
-            self.state.mcu_telemetry.current[i] = 0
-            self.state.mcu_telemetry.voltage[i] = 0.0
-            self.state.mcu_telemetry.temperature[i] = 0
-            self.state.mcu_telemetry.signal_quality[i] = 0.0
-            self._last_telemetry_time[i] = 0.0
+            for packet_type in range(len(_TELEMETRY_FIELDS)):
+                self._clear_telemetry_item(i, packet_type)
 
     def _expire_stale_telemetry(self) -> None:
         now = time.monotonic()
         for i in range(NUM_MOTORS):
-            if (
-                self._last_telemetry_time[i] > 0
-                and now - self._last_telemetry_time[i] > MCU_TELEMETRY_STALE_TIMEOUT_S
-            ):
-                self.state.mcu_telemetry.erpm[i] = 0
-                self.state.mcu_telemetry.current[i] = 0
-                self.state.mcu_telemetry.voltage[i] = 0.0
-                self.state.mcu_telemetry.temperature[i] = 0
-                self.state.mcu_telemetry.signal_quality[i] = 0.0
-                self._last_telemetry_time[i] = 0.0
+            for packet_type, updated_at in enumerate(self._last_telemetry_time[i]):
+                if updated_at > 0 and now - updated_at > MCU_TELEMETRY_STALE_TIMEOUT_S:
+                    self._clear_telemetry_item(i, packet_type)
+
+    def _clear_telemetry_item(self, global_id: int, packet_type: int) -> None:
+        field = _TELEMETRY_FIELDS[packet_type]
+        getattr(self.state.mcu_telemetry, field)[global_id] = 0
+        self._last_telemetry_time[global_id][packet_type] = 0.0
 
     def _update_telemetry(self, packet: bytes | bytearray | memoryview) -> None:
         """Update MCU telemetry from a validated packet.
@@ -396,8 +405,8 @@ class McuSensor:
     def _update_telemetry_item(
         self, global_id: int, packet_type: int, value: int
     ) -> None:
-        if 0 <= global_id < NUM_MOTORS:
-            self._last_telemetry_time[global_id] = time.monotonic()
+        if 0 <= global_id < NUM_MOTORS and 0 <= packet_type < len(_TELEMETRY_FIELDS):
+            self._last_telemetry_time[global_id][packet_type] = time.monotonic()
             if packet_type == MCU_TELEMETRY_TYPE_ERPM:
                 self.state.mcu_telemetry.erpm[global_id] = value * 100
             elif packet_type == MCU_TELEMETRY_TYPE_VOLTAGE:

--- a/src/rov_firmware/websocket/receive/config.py
+++ b/src/rov_firmware/websocket/receive/config.py
@@ -32,12 +32,12 @@ async def handle_get_config(
     log_info("Sent config to client.")
 
 
-def _run_apply_command(binary: str, success_message: str, failure_message: str) -> None:
+def _run_apply_command(binary: str, success_message: str, failure_message: str) -> bool:
     """Run a bounded system configuration helper and report its result."""
     path = shutil.which(binary)
     if path is None:
         log_warn(f"{binary} not found in PATH.")
-        return
+        return False
     try:
         subprocess.run(  # noqa: S603
             [path],
@@ -46,12 +46,14 @@ def _run_apply_command(binary: str, success_message: str, failure_message: str) 
             timeout=_APPLY_COMMAND_TIMEOUT_SECONDS,
         )
         log_info(success_message)
+        return True
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
         log_warn(f"{failure_message}: {error}")
+        return False
 
 
-def _apply_ip_address(ip_address: str) -> None:
-    _run_apply_command(
+def _apply_ip_address(ip_address: str) -> bool:
+    return _run_apply_command(
         "manafish-network",
         f"Applied IP address change to {ip_address}.",
         f"Failed to apply IP address change to {ip_address}",
@@ -135,12 +137,13 @@ async def handle_set_config(
     if state.rov_config.ip_address != old_ip:
         toast_info(
             identifier=None,
-            content=ToastContent(
-                message_key="toasts_rov_ip_address_changing",
-            ),
+            content=ToastContent(message_key="toasts_rov_ip_address_changing"),
             action=None,
         )
-        _apply_ip_address(state.rov_config.ip_address)
+        connection_restart_failed = not await asyncio.to_thread(
+            _apply_ip_address,
+            state.rov_config.ip_address,
+        )
     elif state.rov_config.websocket_port != old_websocket_port:
         connection_restart_failed = not await _restart_firmware()
 
@@ -238,7 +241,10 @@ async def handle_import_config(
             content=ToastContent(message_key="toasts_rov_ip_address_changing"),
             action=None,
         )
-        _apply_ip_address(state.rov_config.ip_address)
+        connection_restart_failed = not await asyncio.to_thread(
+            _apply_ip_address,
+            state.rov_config.ip_address,
+        )
     elif state.rov_config.websocket_port != old_websocket_port:
         connection_restart_failed = not await _restart_firmware()
 

--- a/src/rov_firmware/websocket/receive/mcu.py
+++ b/src/rov_firmware/websocket/receive/mcu.py
@@ -20,6 +20,65 @@ _BOARD_PREFIXES: dict[McuBoard, str] = {
     McuBoard.PICO: "pico",
     McuBoard.PICO2: "pico2",
 }
+_MCU_VERSION_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$"
+)
+
+
+def _version_sort_key(
+    version: str,
+) -> tuple[int, int, int, int, tuple[tuple[int, int | str], ...]]:
+    """Return a SemVer-compatible key for bundled MCU firmware versions."""
+    match = _MCU_VERSION_RE.fullmatch(version)
+    if match is None:
+        return (-1, -1, -1, -1, ())
+
+    prerelease = match.group("prerelease")
+    prerelease_key: tuple[tuple[int, int | str], ...] = ()
+    if prerelease is not None:
+        prerelease_key = tuple(
+            (0, int(identifier)) if identifier.isdigit() else (1, identifier)
+            for identifier in prerelease.split(".")
+        )
+    return (
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+        1 if prerelease is None else 0,
+        prerelease_key,
+    )
+
+
+def mcu_versions_match(reported: str, bundled: str) -> bool:
+    """Compare the three-part version an MCU can report with a bundled SemVer."""
+    match = _MCU_VERSION_RE.fullmatch(bundled)
+    if match is None:
+        return reported == bundled
+    bundled_core = ".".join(match.group(name) for name in ("major", "minor", "patch"))
+    return reported == bundled_core
+
+
+def mcu_update_required(board: McuBoard, reported: str, bundled: str) -> bool:
+    """Return whether the bundled image still needs to be loaded on the board."""
+    if not mcu_versions_match(reported, bundled):
+        return True
+    marker = Path.home() / "mcu-firmware" / f".{_BOARD_PREFIXES[board]}-flashed-version"
+    try:
+        return marker.read_text(encoding="utf-8").strip() != bundled
+    except OSError:
+        # A stable image may already be installed because its full version is
+        # identical to the three-part version the MCU reports. Prereleases need
+        # the marker because their suffix cannot be read back from the MCU.
+        return "-" in bundled
+
+
+def _record_flashed_version(board: McuBoard, version: str) -> None:
+    marker = Path.home() / "mcu-firmware" / f".{_BOARD_PREFIXES[board]}-flashed-version"
+    try:
+        marker.write_text(f"{version}\n", encoding="utf-8")
+    except OSError as error:
+        log_warn(f"Could not record flashed MCU version: {error}")
 
 
 def resolve_mcu_firmware(board: McuBoard) -> tuple[Path, str] | None:
@@ -30,14 +89,14 @@ def resolve_mcu_firmware(board: McuBoard) -> tuple[Path, str] | None:
     """
     prefix = _BOARD_PREFIXES[board]
     mcu_dir = Path.home() / "mcu-firmware"
-    matches = list(mcu_dir.glob(f"{prefix}-v*.uf2"))
-    if not matches:
+    candidates: list[tuple[Path, str]] = []
+    for firmware_path in mcu_dir.glob(f"{prefix}-v*.uf2"):
+        match = re.match(rf"^{re.escape(prefix)}-v(.+)\.uf2$", firmware_path.name)
+        if match is not None and _MCU_VERSION_RE.fullmatch(match.group(1)) is not None:
+            candidates.append((firmware_path, match.group(1)))
+    if not candidates:
         return None
-    firmware_path = matches[0]
-    match = re.match(rf"^{re.escape(prefix)}-v(.+)\.uf2$", firmware_path.name)
-    if not match:
-        return None
-    return firmware_path, match.group(1)
+    return max(candidates, key=lambda candidate: _version_sort_key(candidate[1]))
 
 
 def _report_flash_error(
@@ -126,65 +185,71 @@ async def flash_mcu_firmware(
     Returns:
         True if flash succeeded, False otherwise.
     """
-    resolved = resolve_mcu_firmware(board)
-    if resolved is None:
-        _report_flash_error(
-            f"Firmware flash failed: no firmware file found for {board.value}",
-            show_toasts=show_toasts,
-            toast_identifier=toast_identifier,
-        )
+    if state.mcu_flash_lock.locked():
+        log_warn("Ignoring MCU flash request because another flash is already running.")
         return False
-    firmware_path, _ = resolved
-    picotool_path = _resolve_picotool_path()
 
-    log_info(f"Flashing firmware '{board.value}' from {firmware_path}")
-    try:
-        if picotool_path is None:
+    async with state.mcu_flash_lock:
+        resolved = resolve_mcu_firmware(board)
+        if resolved is None:
             _report_flash_error(
-                "Firmware flash failed: picotool not found",
+                f"Firmware flash failed: no firmware file found for {board.value}",
                 show_toasts=show_toasts,
                 toast_identifier=toast_identifier,
             )
             return False
+        firmware_path, firmware_version = resolved
+        picotool_path = _resolve_picotool_path()
 
-        state.mcu_flashing = True
-        process = subprocess.Popen(  # noqa: S603
-            [picotool_path, "load", "-f", "-x", str(firmware_path)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-        loop = asyncio.get_running_loop()
-        rc, output = await loop.run_in_executor(
-            None, _process_flash_output, process, toast_identifier
-        )
-
-        if rc == 0:
-            log_info("Firmware flash succeeded.")
-            if show_toasts:
-                toast_success(
-                    identifier=toast_identifier,
-                    content=ToastContent(message_key="toasts_flash_success"),
-                    action=None,
+        log_info(f"Flashing firmware '{board.value}' from {firmware_path}")
+        try:
+            if picotool_path is None:
+                _report_flash_error(
+                    "Firmware flash failed: picotool not found",
+                    show_toasts=show_toasts,
+                    toast_identifier=toast_identifier,
                 )
-            return True
+                return False
 
-        _report_flash_error(
-            f"Firmware flash failed (rc={rc}):\n{output}",
-            show_toasts=show_toasts,
-            toast_identifier=toast_identifier,
-        )
-        return False
-    except Exception as ex:
-        _report_flash_error(
-            f"Unexpected firmware flash error: {ex}",
-            show_toasts=show_toasts,
-            unexpected=True,
-            toast_identifier=toast_identifier,
-        )
-        return False
-    finally:
-        state.mcu_flashing = False
+            state.mcu_flashing = True
+            process = subprocess.Popen(  # noqa: S603
+                [picotool_path, "load", "-f", "-x", str(firmware_path)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            loop = asyncio.get_running_loop()
+            rc, output = await loop.run_in_executor(
+                None, _process_flash_output, process, toast_identifier
+            )
+
+            if rc == 0:
+                _record_flashed_version(board, firmware_version)
+                log_info("Firmware flash succeeded.")
+                if show_toasts:
+                    toast_success(
+                        identifier=toast_identifier,
+                        content=ToastContent(message_key="toasts_flash_success"),
+                        action=None,
+                    )
+                return True
+
+            _report_flash_error(
+                f"Firmware flash failed (rc={rc}):\n{output}",
+                show_toasts=show_toasts,
+                toast_identifier=toast_identifier,
+            )
+            return False
+        except Exception as ex:
+            _report_flash_error(
+                f"Unexpected firmware flash error: {ex}",
+                show_toasts=show_toasts,
+                unexpected=True,
+                toast_identifier=toast_identifier,
+            )
+            return False
+        finally:
+            state.mcu_flashing = False
 
 
 async def handle_flash_mcu_firmware(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,8 @@ from rov_firmware.models.config import (
     ("version", "expected"),
     [
         ("1.2.3", (1, 2, 3)),
-        ("1.0", (1, 0, 0)),
+        ("1.2.3-rc.4", (1, 2, 3)),
+        ("1.0", (0, 0, 0)),
         ("", (0, 0, 0)),
         ("abc", (0, 0, 0)),
         (None, (0, 0, 0)),
@@ -41,6 +42,8 @@ def test_parse_semver(version, expected):
         ("1.0.0", "1.0.1", -1),
         ("1.2.3", "1.2.3", 0),
         ("2.0.0", "1.9.9", 1),
+        ("1.1.6-rc.2", "1.1.6-rc.3", -1),
+        ("1.1.6-rc.3", "1.1.6", -1),
     ],
 )
 def test_compare_semver(left, right, expected):
@@ -94,7 +97,7 @@ def test_1_1_6_migration_removes_internal_resistance_and_updates_old_depth_defau
 
     migrated = apply_migrations(raw)
 
-    assert migrated["firmwareVersion"] == "1.1.6"
+    assert migrated["firmwareVersion"] == "1.1.6-rc.1"
     assert migrated["power"] == {"minBatteryVoltage": 16}
     assert migrated["regulator"]["depth"] == {
         "kp": 2,
@@ -122,6 +125,18 @@ def test_rov_config_accepts_supported_dshot_speeds(dshot_speed):
     config = RovConfig(dshot_speed=dshot_speed)
 
     assert config.dshot_speed == dshot_speed
+
+
+@pytest.mark.parametrize("ip_address", ["not-an-ip", "10.10.10.0", "10.10.10.255"])
+def test_rov_config_rejects_invalid_or_reserved_ip_address(ip_address):
+    with pytest.raises(ValidationError):
+        RovConfig(ip_address=ip_address)
+
+
+@pytest.mark.parametrize("websocket_port", [0, 65536])
+def test_rov_config_rejects_invalid_websocket_port(websocket_port):
+    with pytest.raises(ValidationError):
+        RovConfig(websocket_port=websocket_port)
 
 
 def test_rov_config_rejects_dshot_1200_for_pico():

--- a/tests/test_import_config.py
+++ b/tests/test_import_config.py
@@ -163,7 +163,11 @@ def test_import_applies_network_once_when_ip_and_port_changed(rov_state, monkeyp
         restart_calls.append(None)
         return True
 
-    monkeypatch.setattr(config_handlers, "_apply_ip_address", network_calls.append)
+    def apply_ip_address(ip_address: str) -> bool:
+        network_calls.append(ip_address)
+        return True
+
+    monkeypatch.setattr(config_handlers, "_apply_ip_address", apply_ip_address)
     monkeypatch.setattr(config_handlers, "_restart_firmware", restart_firmware)
 
     payload = _baseline_export(rov_state)

--- a/tests/test_mcu_flash.py
+++ b/tests/test_mcu_flash.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+from rov_firmware.models.config import McuBoard
+from rov_firmware.websocket.receive import mcu
+
+
+def test_resolve_mcu_firmware_selects_latest_semver(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    firmware_dir = tmp_path / "mcu-firmware"
+    firmware_dir.mkdir()
+    old = firmware_dir / "pico-v1.0.2.uf2"
+    prerelease = firmware_dir / "pico-v1.0.3-rc.1.uf2"
+    old.touch()
+    prerelease.touch()
+
+    assert mcu.resolve_mcu_firmware(McuBoard.PICO) == (prerelease, "1.0.3-rc.1")
+
+
+def test_resolve_mcu_firmware_prefers_stable_for_same_core(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    firmware_dir = tmp_path / "mcu-firmware"
+    firmware_dir.mkdir()
+    (firmware_dir / "pico2-v1.0.3-rc.2.uf2").touch()
+    stable = firmware_dir / "pico2-v1.0.3.uf2"
+    stable.touch()
+
+    assert mcu.resolve_mcu_firmware(McuBoard.PICO2) == (stable, "1.0.3")
+
+
+def test_prerelease_bundle_matches_three_part_mcu_version():
+    assert mcu.mcu_versions_match("1.0.3", "1.0.3-rc.1")
+    assert not mcu.mcu_versions_match("1.0.2", "1.0.3-rc.1")
+
+
+def test_prerelease_requires_one_flash_per_exact_bundle(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    firmware_dir = tmp_path / "mcu-firmware"
+    firmware_dir.mkdir()
+
+    assert mcu.mcu_update_required(McuBoard.PICO, "1.0.3", "1.0.3-rc.1")
+
+    (firmware_dir / ".pico-flashed-version").write_text(
+        "1.0.3-rc.1\n", encoding="utf-8"
+    )
+
+    assert not mcu.mcu_update_required(McuBoard.PICO, "1.0.3", "1.0.3-rc.1")
+    assert mcu.mcu_update_required(McuBoard.PICO, "1.0.3", "1.0.3-rc.2")
+
+
+def test_stable_same_core_replaces_recorded_prerelease(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    firmware_dir = tmp_path / "mcu-firmware"
+    firmware_dir.mkdir()
+    marker = firmware_dir / ".pico-flashed-version"
+    marker.write_text("1.0.3-rc.2\n", encoding="utf-8")
+
+    assert mcu.mcu_update_required(McuBoard.PICO, "1.0.3", "1.0.3")
+
+    marker.write_text("1.0.3\n", encoding="utf-8")
+
+    assert not mcu.mcu_update_required(McuBoard.PICO, "1.0.3", "1.0.3")
+
+
+def test_unmarked_matching_stable_does_not_flash(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / "mcu-firmware").mkdir()
+
+    assert not mcu.mcu_update_required(McuBoard.PICO2, "1.0.3", "1.0.3")

--- a/tests/test_mcu_sensor.py
+++ b/tests/test_mcu_sensor.py
@@ -1,6 +1,11 @@
 import asyncio
 
-from rov_firmware.constants import MCU_PROTOCOL_DSHOT, MCU_VERSION_START_BYTE
+from rov_firmware.constants import (
+    MCU_PROTOCOL_DSHOT,
+    MCU_TELEMETRY_TYPE_CURRENT,
+    MCU_TELEMETRY_TYPE_SIGNAL_QUALITY,
+    MCU_VERSION_START_BYTE,
+)
 from rov_firmware.models.config import ThrusterProtocol
 from rov_firmware.sensors import mcu as mcu_module
 from rov_firmware.sensors.mcu import McuSensor
@@ -43,3 +48,38 @@ def test_version_packet_acknowledges_mcu_without_reverting_requested_config(
     assert rov_state.rov_config.thruster_protocol == ThrusterProtocol.PWM
     assert rov_state.rov_config.dshot_speed == 300
     assert queue.get_nowait().payload.thruster_protocol == ThrusterProtocol.PWM
+
+
+def test_version_packet_does_not_reflash_matching_prerelease_bundle(
+    rov_state, monkeypatch
+):
+    queue = asyncio.Queue()
+    monkeypatch.setattr(mcu_module, "get_message_queue", lambda: queue)
+    serial_manager = SerialManager(rov_state)
+    sensor = McuSensor(rov_state, serial_manager)
+    monkeypatch.setattr(sensor, "_get_expected_version", lambda: "1.2.3-rc.1")
+    monkeypatch.setattr(mcu_module, "mcu_update_required", lambda *_args: False)
+
+    def unexpected_flash() -> None:
+        msg = "unexpected flash"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(sensor, "_flash_mcu", unexpected_flash)
+
+    sensor._handle_version_packet(_version_packet(MCU_PROTOCOL_DSHOT, 600))
+
+    assert rov_state.rov_config.mcu_firmware_version == "1.2.3"
+
+
+def test_signal_quality_updates_do_not_keep_stale_current_alive(rov_state, monkeypatch):
+    now = 10.0
+    monkeypatch.setattr(mcu_module.time, "monotonic", lambda: now)
+    sensor = McuSensor(rov_state, SerialManager(rov_state))
+    sensor._update_telemetry_item(0, MCU_TELEMETRY_TYPE_CURRENT, 42)
+
+    now = 14.0
+    sensor._update_telemetry_item(0, MCU_TELEMETRY_TYPE_SIGNAL_QUALITY, 10_000)
+    sensor._expire_stale_telemetry()
+
+    assert rov_state.mcu_telemetry.current[0] == 0
+    assert rov_state.mcu_telemetry.signal_quality[0] == 100

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -147,11 +147,12 @@ def test_set_config_applies_network_once_when_ip_and_port_changed(
 ):
     network_calls: list[str] = []
     restart_calls: list[None] = []
-    monkeypatch.setattr(
-        config_handlers,
-        "_apply_ip_address",
-        network_calls.append,
-    )
+
+    def apply_ip_address(ip_address: str) -> bool:
+        network_calls.append(ip_address)
+        return True
+
+    monkeypatch.setattr(config_handlers, "_apply_ip_address", apply_ip_address)
 
     async def restart_firmware() -> bool:
         restart_calls.append(None)
@@ -166,6 +167,30 @@ def test_set_config_applies_network_once_when_ip_and_port_changed(
 
     assert network_calls == ["10.10.11.10"]
     assert restart_calls == []
+
+
+def test_set_config_reports_network_apply_failure_without_success(
+    rov_state, monkeypatch
+):
+    success_calls: list[None] = []
+    warning_keys: list[str] = []
+    monkeypatch.setattr(config_handlers, "_apply_ip_address", lambda _address: False)
+    monkeypatch.setattr(
+        config_handlers,
+        "toast_success",
+        lambda **_kwargs: success_calls.append(None),
+    )
+    monkeypatch.setattr(
+        config_handlers,
+        "toast_warn",
+        lambda *, content, **_kwargs: warning_keys.append(content.message_key),
+    )
+
+    payload = PartialRovConfig.model_validate({"ipAddress": "10.10.11.10"})
+    asyncio.run(handle_set_config(rov_state, payload))
+
+    assert success_calls == []
+    assert warning_keys == ["toasts_rov_connection_restart_failed"]
 
 
 def test_set_config_reports_restart_failure_without_success(rov_state, monkeypatch):


### PR DESCRIPTION
## Summary

- apply ROV IP and camera changes through helpers available inside the firmware service, and report apply failures
- serialize Pico flashing, select the latest bundled SemVer deterministically, and remember the exact RC that was flashed so three-part MCU version reports do not trigger a flash loop
- prune stale bundled UF2 files while preserving corrective flashes for genuinely mismatched MCU core versions
- expire each EDT telemetry field independently so absent current telemetry cannot remain stale while signal data continues
- validate usable ROV IPv4 hosts and WebSocket ports and compare prerelease schema versions correctly

## Testing

- uv run ruff format --check .
- uv run ruff check .
- uv run ty check
- uv run pytest (144 passed)
- nix fmt -- --ci .
- nix flake check --show-trace
- nix build --accept-flake-config --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved MCU firmware update detection with semantic-version and prerelease support.
  * Prevented duplicate firmware flashing and selected the most appropriate available firmware.
  * Added validation for IPv4 addresses and WebSocket ports.
  * Network configuration failures now provide clearer restart feedback.
  * Improved telemetry tracking and expiration behavior.

* **Bug Fixes**
  * Removed stale firmware files during setup.
  * Prevented outdated telemetry and concurrent update operations from causing inconsistent device state.

* **Tests**
  * Expanded coverage for firmware updates, networking, validation, and telemetry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->