### PR TITLE
fix(firmware): report Pi supply undervoltage

### DIFF
--- a/src/rov_firmware/models/rov_status.py
+++ b/src/rov_firmware/models/rov_status.py
@@ -11,4 +11,5 @@ class RovStatus(CamelCaseModel):
     depth_hold: bool
     battery_percentage: int
     current_draw: int
+    pi_undervoltage: bool
     health: SystemHealth

--- a/src/rov_firmware/sensors/pi_power.py
+++ b/src/rov_firmware/sensors/pi_power.py
@@ -1,0 +1,39 @@
+"""Raspberry Pi input-power monitoring."""
+
+from pathlib import Path
+
+
+HWMON_ROOT = Path("/sys/class/hwmon")
+RPI_VOLTAGE_SENSOR_NAME = "rpi_volt"
+
+
+def is_pi_undervoltage_detected(hwmon_root: Path = HWMON_ROOT) -> bool:
+    """Return whether the Raspberry Pi firmware detected input undervoltage.
+
+    The ``raspberrypi-hwmon`` kernel driver polls the firmware throttling flags
+    and exposes the undervoltage alarm through ``in0_lcrit_alarm``. The hwmon
+    index is assigned dynamically, so identify the sensor by name instead of
+    assuming a fixed ``hwmonN`` path.
+
+    Args:
+        hwmon_root: hwmon class directory, injectable for tests.
+
+    Returns:
+        True while the kernel's Raspberry Pi voltage alarm is asserted. Missing
+        or unreadable hwmon data is treated as unavailable rather than as an
+        undervoltage event.
+    """
+    try:
+        for device in hwmon_root.glob("hwmon*"):
+            try:
+                sensor_name = (device / "name").read_text(encoding="ascii").strip()
+                if sensor_name != RPI_VOLTAGE_SENSOR_NAME:
+                    continue
+                alarm = (device / "in0_lcrit_alarm").read_text(encoding="ascii")
+                return alarm.strip() == "1"
+            except OSError:
+                continue
+    except OSError:
+        return False
+
+    return False

--- a/src/rov_firmware/websocket/send/status.py
+++ b/src/rov_firmware/websocket/send/status.py
@@ -2,6 +2,7 @@
 
 from ...models.rov_status import RovStatus
 from ...rov_state import RovState
+from ...sensors.pi_power import is_pi_undervoltage_detected
 from ..message import StatusUpdate
 
 
@@ -30,6 +31,7 @@ def build_status_update(state: RovState) -> StatusUpdate:
         depth_hold=state.system_status.depth_hold,
         battery_percentage=int(state.system_status.battery_percentage),
         current_draw=current_draw,
+        pi_undervoltage=is_pi_undervoltage_detected(),
         health=state.system_health,
     )
     return StatusUpdate(payload=payload)

--- a/src/tools/mock_websocket_server.py
+++ b/src/tools/mock_websocket_server.py
@@ -198,6 +198,7 @@ async def _handle_client(websocket: ServerConnection) -> None:  # noqa: C901,PLR
                     "depthHold": SYSTEM_STATUS["depthHold"],
                     "batteryPercentage": battery_percentage,
                     "currentDraw": current_draw,
+                    "piUndervoltage": False,
                     "health": {
                         "mcuHealthy": True,
                         "imuHealthy": True,

--- a/tests/test_pi_power.py
+++ b/tests/test_pi_power.py
@@ -1,0 +1,34 @@
+from rov_firmware.sensors.pi_power import is_pi_undervoltage_detected
+
+
+def _create_hwmon_sensor(root, index: int, name: str, alarm: str) -> None:
+    sensor = root / f"hwmon{index}"
+    sensor.mkdir()
+    (sensor / "name").write_text(name, encoding="ascii")
+    (sensor / "in0_lcrit_alarm").write_text(alarm, encoding="ascii")
+
+
+def test_reads_raspberry_pi_undervoltage_alarm(tmp_path):
+    _create_hwmon_sensor(tmp_path, 0, "other_sensor\n", "1\n")
+    _create_hwmon_sensor(tmp_path, 3, "rpi_volt\n", "1\n")
+
+    assert is_pi_undervoltage_detected(tmp_path)
+
+
+def test_reports_normal_voltage_when_alarm_is_clear(tmp_path):
+    _create_hwmon_sensor(tmp_path, 1, "rpi_volt\n", "0\n")
+
+    assert not is_pi_undervoltage_detected(tmp_path)
+
+
+def test_reports_unavailable_sensor_as_normal(tmp_path):
+    assert not is_pi_undervoltage_detected(tmp_path)
+
+
+def test_skips_unreadable_or_incomplete_hwmon_devices(tmp_path):
+    incomplete = tmp_path / "hwmon0"
+    incomplete.mkdir()
+    (incomplete / "name").write_text("rpi_volt\n", encoding="ascii")
+    _create_hwmon_sensor(tmp_path, 1, "rpi_volt\n", "1\n")
+
+    assert is_pi_undervoltage_detected(tmp_path)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,10 @@
+from rov_firmware.websocket.send import status
+
+
+def test_status_reports_pi_undervoltage(rov_state, monkeypatch):
+    monkeypatch.setattr(status, "is_pi_undervoltage_detected", lambda: True)
+
+    message = status.build_status_update(rov_state)
+
+    assert message.payload.pi_undervoltage is True
+    assert message.model_dump(by_alias=True)["payload"]["piUndervoltage"] is True


### PR DESCRIPTION
## Summary
- read Raspberry Pi undervoltage from the kernel `rpi_volt` hwmon alarm
- expose `piUndervoltage` in periodic status frames
- keep the mock WebSocket server aligned with the status schema
- add sysfs and wire-payload coverage

## Compatibility
This is an additive status field. Existing apps ignore it. The paired app change defaults it to `false` when connected to older firmware.

## Testing
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` (149 passed)

Paired app PR: https://github.com/manafishrov/app/pull/177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Raspberry Pi input-power monitoring to detect undervoltage conditions.
  - Included Raspberry Pi undervoltage status in system status updates.

- **Bug Fixes**
  - Status reporting now accurately reflects detected Raspberry Pi power alarms.

- **Tests**
  - Added coverage for active, cleared, missing, and incomplete power-monitoring sensors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->