### PR TITLE
fix(control): harden field update workflows

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,13 +35,13 @@
     "esc-firmware": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-NTSzdWQWxHPoyRhEZa18rMrVsA9Puwcrhui9HNGglhk=",
+        "narHash": "sha256-mgGjBMSjAyC5FG73i2loPbhlYaOcXPIubgqQd7cRpQk=",
         "type": "file",
-        "url": "https://github.com/manafishrov/AM32/releases/download/v2.20.0-rc.3/AM32_SKYSTARS_AM60_V2_F421_2.20.0.bin"
+        "url": "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.1/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/AM32/releases/download/v2.20.0-rc.3/AM32_SKYSTARS_AM60_V2_F421_2.20.0.bin"
+        "url": "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.1/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin"
       }
     },
     "flake-compat": {

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
       flake = false;
     };
     esc-firmware = {
-      url = "https://github.com/manafishrov/AM32/releases/download/v2.20.0-rc.3/AM32_SKYSTARS_AM60_V2_F421_2.20.0.bin";
+      url = "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.1/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin";
       flake = false;
     };
   };

--- a/src/rov_firmware/models/sensors.py
+++ b/src/rov_firmware/models/sensors.py
@@ -12,6 +12,7 @@ class McuData(BaseModel):
 
     erpm: list[int] = [0, 0, 0, 0, 0, 0, 0, 0]
     current: list[int] = [0, 0, 0, 0, 0, 0, 0, 0]
+    current_valid: list[bool] = [False, False, False, False, False, False, False, False]
     voltage: list[float] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     temperature: list[int] = [0, 0, 0, 0, 0, 0, 0, 0]
     signal_quality: list[float] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]

--- a/src/rov_firmware/sensors/mcu.py
+++ b/src/rov_firmware/sensors/mcu.py
@@ -107,7 +107,9 @@ class McuSensor:
         ]
         self._startup_time: float = time.monotonic()
         self._flash_task: asyncio.Task[None] | None = None
+        self._mcu_auto_flash_attempted = False
         self._esc_firmware_flash_task: asyncio.Task[None] | None = None
+        self._esc_auto_flash_attempted = False
         self._esc_firmware_reconcile_task: asyncio.Task[None] | None = None
         self._esc_version_lengths: list[int | None] = [None] * NUM_MOTORS
         self._esc_version_buffers: list[bytearray] = [
@@ -389,6 +391,9 @@ class McuSensor:
         if self._flash_task is not None and not self._flash_task.done():
             return
 
+        if self._mcu_auto_flash_attempted:
+            return
+
         if not self._auto_update_window_open():
             log_warn(
                 f"MCU firmware mismatch ({current_version} != {expected_version}) detected, "
@@ -399,6 +404,7 @@ class McuSensor:
         log_warn(
             f"MCU firmware mismatch: current is {current_version}, expected is {expected_version}. Auto-flashing."
         )
+        self._mcu_auto_flash_attempted = True
         self._flash_task = asyncio.get_running_loop().create_task(self._flash_mcu())
 
     async def _flash_mcu(self) -> None:
@@ -420,7 +426,7 @@ class McuSensor:
             return
         if self.state.mcu_flashing:
             return
-        if (
+        if self._esc_auto_flash_attempted or (
             self._esc_firmware_flash_task is not None
             and not self._esc_firmware_flash_task.done()
         ):
@@ -439,6 +445,7 @@ class McuSensor:
         log_warn(
             f"ESC firmware {version} has not been applied. Auto-flashing all ESCs."
         )
+        self._esc_auto_flash_attempted = True
         self._esc_firmware_flash_task = loop.create_task(self._flash_esc_firmware())
 
     async def _flash_esc_firmware(self) -> None:

--- a/src/rov_firmware/sensors/mcu.py
+++ b/src/rov_firmware/sensors/mcu.py
@@ -30,7 +30,6 @@ from ..constants import (
     MCU_TELEMETRY_TYPE_VOLTAGE,
     MCU_VERSION_PACKET_SIZE,
     MCU_VERSION_START_BYTE,
-    MOTORS_PER_BUS,
     NUM_MOTORS,
 )
 from ..esc_firmware import (
@@ -40,7 +39,7 @@ from ..esc_firmware import (
     resolve_esc_firmware,
 )
 from ..log import log_error, log_info, log_warn
-from ..models.config import CurrentSensingMode, ThrusterProtocol
+from ..models.config import ThrusterProtocol
 from ..models.log import LogLevel, LogOrigin
 from ..rov_state import RovState
 from ..serial import SerialManager
@@ -483,6 +482,8 @@ class McuSensor:
     def _clear_telemetry_item(self, global_id: int, packet_type: int) -> None:
         field = _TELEMETRY_FIELDS[packet_type]
         getattr(self.state.mcu_telemetry, field)[global_id] = 0
+        if packet_type == MCU_TELEMETRY_TYPE_CURRENT:
+            self.state.mcu_telemetry.current_valid[global_id] = False
         self._last_telemetry_time[global_id][packet_type] = 0.0
 
     def _update_telemetry(self, packet: bytes | bytearray | memoryview) -> None:
@@ -522,15 +523,12 @@ class McuSensor:
             elif packet_type == MCU_TELEMETRY_TYPE_TEMPERATURE:
                 self.state.mcu_telemetry.temperature[global_id] = value
             elif packet_type == MCU_TELEMETRY_TYPE_CURRENT:
-                if (
-                    self.state.rov_config.current_sensing_mode
-                    == CurrentSensingMode.SHARED_BUS
-                ):
-                    self.state.mcu_telemetry.current[global_id] = (
-                        value // MOTORS_PER_BUS
-                    )
-                else:
-                    self.state.mcu_telemetry.current[global_id] = value
+                # EDT current is already in whole amperes. Preserve the raw reading
+                # here so changing the configured sensor topology cannot leave a mix
+                # of divided and undivided samples in state. Shared-bus de-duplication
+                # belongs at aggregation time.
+                self.state.mcu_telemetry.current[global_id] = max(0, value)
+                self.state.mcu_telemetry.current_valid[global_id] = True
             elif packet_type == MCU_TELEMETRY_TYPE_SIGNAL_QUALITY:
                 self.state.mcu_telemetry.signal_quality[global_id] = value / 100
 

--- a/src/rov_firmware/websocket/handler.py
+++ b/src/rov_firmware/websocket/handler.py
@@ -27,10 +27,28 @@ from .receive.regulator import (
     handle_start_regulator_auto_tuning,
 )
 from .receive.state import (
+    handle_set_auto_stabilization,
+    handle_set_depth_hold,
     handle_toggle_auto_stabilization,
     handle_toggle_depth_hold,
 )
 from .types import MessageType
+
+
+async def _handle_state_payload_message(
+    state: RovState,
+    payload: object,
+    message_type: MessageType,
+) -> bool:
+    match message_type:
+        case MessageType.SET_AUTO_STABILIZATION:
+            await handle_set_auto_stabilization(state, cast(bool, payload))
+        case MessageType.SET_DEPTH_HOLD:
+            await handle_set_depth_hold(state, cast(bool, payload))
+        case _:
+            return False
+
+    return True
 
 
 async def _handle_payload_message(
@@ -56,7 +74,7 @@ async def _handle_payload_message(
         case MessageType.SET_DESIRED_DEPTH:
             await handle_set_desired_depth(state, cast(float, payload))
         case _:
-            return False
+            return await _handle_state_payload_message(state, payload, message.type)
 
     return True
 

--- a/src/rov_firmware/websocket/message.py
+++ b/src/rov_firmware/websocket/message.py
@@ -129,6 +129,22 @@ class ToggleDepthHold(CamelCaseModel):
     type: Literal[MessageType.TOGGLE_DEPTH_HOLD] = MessageType.TOGGLE_DEPTH_HOLD
 
 
+class SetAutoStabilization(CamelCaseModel):
+    """WebSocket message for setting auto stabilization idempotently."""
+
+    type: Literal[MessageType.SET_AUTO_STABILIZATION] = (
+        MessageType.SET_AUTO_STABILIZATION
+    )
+    payload: bool
+
+
+class SetDepthHold(CamelCaseModel):
+    """WebSocket message for setting depth hold idempotently."""
+
+    type: Literal[MessageType.SET_DEPTH_HOLD] = MessageType.SET_DEPTH_HOLD
+    payload: bool
+
+
 class SetDesiredDepth(CamelCaseModel):
     """WebSocket message for setting the desired depth."""
 
@@ -167,6 +183,8 @@ WebsocketMessage = Annotated[
     | CustomAction
     | ToggleAutoStabilization
     | ToggleDepthHold
+    | SetAutoStabilization
+    | SetDepthHold
     | SetDesiredDepth
     | FlashMcuFirmware
     | FlashEscFirmware,

--- a/src/rov_firmware/websocket/receive/config.py
+++ b/src/rov_firmware/websocket/receive/config.py
@@ -120,6 +120,9 @@ async def _apply_connection_change(
             state.rov_config.ip_address,
         )
     else:
+        applied = True
+
+    if applied and port_changed:
         applied = await _restart_firmware()
 
     if applied:

--- a/src/rov_firmware/websocket/receive/config.py
+++ b/src/rov_firmware/websocket/receive/config.py
@@ -99,6 +99,56 @@ async def _restart_firmware() -> bool:
     return True
 
 
+async def _apply_connection_change(
+    state: RovState,
+    previous_config: RovConfig,
+) -> bool:
+    """Apply connection settings, restoring the persisted config on failure."""
+    ip_changed = state.rov_config.ip_address != previous_config.ip_address
+    port_changed = state.rov_config.websocket_port != previous_config.websocket_port
+    if not ip_changed and not port_changed:
+        return True
+
+    if ip_changed:
+        toast_info(
+            identifier=None,
+            content=ToastContent(message_key="toasts_rov_ip_address_changing"),
+            action=None,
+        )
+        applied = await asyncio.to_thread(
+            _apply_ip_address,
+            state.rov_config.ip_address,
+        )
+    else:
+        applied = await _restart_firmware()
+
+    if applied:
+        return True
+
+    failed_ip = state.rov_config.ip_address
+    state.rov_config = previous_config
+    state.rov_config.save()
+    log_warn("Restored the previous ROV connection config after apply failure.")
+
+    if ip_changed:
+        rollback_applied = await asyncio.to_thread(
+            _apply_ip_address,
+            previous_config.ip_address,
+        )
+        if not rollback_applied:
+            log_warn(
+                f"Could not restore network address {previous_config.ip_address} "
+                f"after failed change to {failed_ip}."
+            )
+
+    toast_warn(
+        identifier=None,
+        content=ToastContent(message_key="toasts_rov_connection_restart_failed"),
+        action=None,
+    )
+    return False
+
+
 def _apply_camera() -> None:
     _run_apply_command(
         "manafish-camera",
@@ -117,9 +167,8 @@ async def handle_set_config(
         state: The ROV state.
         payload: Partial ROV configuration update.
     """
-    old_ip = state.rov_config.ip_address
-    old_websocket_port = state.rov_config.websocket_port
-    previous_camera = state.rov_config.camera
+    previous_config = state.rov_config.model_copy(deep=True)
+    previous_camera = previous_config.camera
     current_data = state.rov_config.model_dump(by_alias=False)
     update_data = payload.model_dump(by_alias=False, include=payload.model_fields_set)
     if payload.camera is not None:
@@ -132,33 +181,13 @@ async def handle_set_config(
     state.rov_config = RovConfig.model_validate(current_data)
     state.rov_config.save()
     log_info("Received and applied config update.")
-    connection_restart_failed = False
+    if not await _apply_connection_change(state, previous_config):
+        await get_message_queue().put(Config(payload=state.rov_config))
+        return
 
-    if state.rov_config.ip_address != old_ip:
-        toast_info(
-            identifier=None,
-            content=ToastContent(message_key="toasts_rov_ip_address_changing"),
-            action=None,
-        )
-        connection_restart_failed = not await asyncio.to_thread(
-            _apply_ip_address,
-            state.rov_config.ip_address,
-        )
-    elif state.rov_config.websocket_port != old_websocket_port:
-        connection_restart_failed = not await _restart_firmware()
-
+    await get_message_queue().put(Config(payload=state.rov_config))
     if state.rov_config.camera != previous_camera:
         _apply_camera()
-
-    if connection_restart_failed:
-        toast_warn(
-            identifier=None,
-            content=ToastContent(
-                message_key="toasts_rov_connection_restart_failed",
-            ),
-            action=None,
-        )
-        return
 
     toast_success(
         identifier=None,
@@ -202,9 +231,8 @@ async def handle_import_config(
         payload: Raw config dictionary from the app, possibly from an older or
             newer firmware version.
     """
-    old_ip = state.rov_config.ip_address
-    old_websocket_port = state.rov_config.websocket_port
-    previous_camera = state.rov_config.camera
+    previous_config = state.rov_config.model_copy(deep=True)
+    previous_camera = previous_config.camera
     migration_input = dict(payload)
     board_was_omitted = "mcuBoard" not in migration_input
     if board_was_omitted:
@@ -228,37 +256,16 @@ async def handle_import_config(
     new_config.firmware_version = state.rov_config.firmware_version
     state.rov_config = new_config
     state.rov_config.save()
-    await get_message_queue().put(Config(payload=state.rov_config))
     log_info(
         f"Imported config from app. Skipped fields: {skipped or 'none'}.",
     )
-    connection_restart_failed = False
+    if not await _apply_connection_change(state, previous_config):
+        await get_message_queue().put(Config(payload=state.rov_config))
+        return
 
-    if state.rov_config.ip_address != old_ip:
-        toast_info(
-            identifier=None,
-            content=ToastContent(message_key="toasts_rov_ip_address_changing"),
-            action=None,
-        )
-        connection_restart_failed = not await asyncio.to_thread(
-            _apply_ip_address,
-            state.rov_config.ip_address,
-        )
-    elif state.rov_config.websocket_port != old_websocket_port:
-        connection_restart_failed = not await _restart_firmware()
-
+    await get_message_queue().put(Config(payload=state.rov_config))
     if state.rov_config.camera != previous_camera:
         _apply_camera()
-
-    if connection_restart_failed:
-        toast_warn(
-            identifier=None,
-            content=ToastContent(
-                message_key="toasts_rov_connection_restart_failed",
-            ),
-            action=None,
-        )
-        return
 
     if skipped:
         toast_warn(

--- a/src/rov_firmware/websocket/receive/mcu.py
+++ b/src/rov_firmware/websocket/receive/mcu.py
@@ -24,6 +24,7 @@ _MCU_VERSION_RE = re.compile(
     r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
     r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$"
 )
+_COMPLETE_PERCENT = 100
 
 
 def _version_sort_key(
@@ -116,7 +117,6 @@ def _report_flash_error(
                     if unexpected
                     else "toasts_flash_failed"
                 ),
-                description_key="toasts_flash_board_hint",
             ),
             action=None,
         )
@@ -135,12 +135,14 @@ def _resolve_picotool_path() -> str | None:
 
 def _process_flash_output(
     process: subprocess.Popen[str], toast_identifier: str
-) -> tuple[int, str]:
+) -> tuple[int, str, bool]:
     if process.stdout is None:
-        return -1, ""
+        return -1, "", False
 
     all_output: list[str] = []
     percent = 0
+    verification_reached_100 = False
+    verification_succeeded = False
     while True:
         output = process.stdout.readline()
         if output == "" and process.poll() is not None:
@@ -148,23 +150,60 @@ def _process_flash_output(
         if output:
             line = output.rstrip()
             all_output.append(line)
+            percent = _update_load_progress(line, percent, toast_identifier)
+            verification_reached_100, verification_succeeded = (
+                _update_verification_status(
+                    line,
+                    verification_reached_100,
+                    verification_succeeded,
+                )
+            )
 
-            if "Loading into Flash:" in line:
-                match = re.search(r"(\d+)%", line)
-                if match:
-                    new_percent = int(match.group(1))
-                    if new_percent != percent:
-                        percent = new_percent
-                        toast_loading(
-                            identifier=toast_identifier,
-                            content=ToastContent(
-                                message_key="toasts_flash_in_progress",
-                                message_args={"percent": percent},
-                            ),
-                            action=None,
-                        )
+    return (
+        cast(int, process.poll()),
+        "\n".join(all_output),
+        verification_succeeded,
+    )
 
-    return cast(int, process.poll()), "\n".join(all_output)
+
+def _picotool_progress(line: str, prefix: str) -> int | None:
+    if prefix not in line:
+        return None
+    match = re.search(r"(\d+)%", line)
+    return int(match.group(1)) if match else None
+
+
+def _update_load_progress(line: str, percent: int, toast_identifier: str) -> int:
+    new_percent = _picotool_progress(line, "Loading into Flash:")
+    if new_percent is None or new_percent == percent:
+        return percent
+    toast_loading(
+        identifier=toast_identifier,
+        content=ToastContent(
+            message_key="toasts_flash_in_progress",
+            message_args={"percent": new_percent},
+        ),
+        action=None,
+    )
+    return new_percent
+
+
+def _update_verification_status(
+    line: str,
+    reached_100: bool,
+    succeeded: bool,
+) -> tuple[bool, bool]:
+    verification_percent = _picotool_progress(line, "Verifying Flash:")
+    if verification_percent is not None and verification_percent >= _COMPLETE_PERCENT:
+        reached_100 = True
+    if reached_100 and line.strip() == "OK":
+        succeeded = True
+    return reached_100, succeeded
+
+
+def _flash_write_completed(return_code: int, verification_succeeded: bool) -> bool:
+    """Accept a verified write even if picotool failed only while executing it."""
+    return return_code == 0 or verification_succeeded
 
 
 async def flash_mcu_firmware(
@@ -213,17 +252,23 @@ async def flash_mcu_firmware(
 
             state.mcu_flashing = True
             process = subprocess.Popen(  # noqa: S603
-                [picotool_path, "load", "-f", "-x", str(firmware_path)],
+                [picotool_path, "load", "-f", "-v", "-x", str(firmware_path)],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
             )
             loop = asyncio.get_running_loop()
-            rc, output = await loop.run_in_executor(
+            rc, output, verification_succeeded = await loop.run_in_executor(
                 None, _process_flash_output, process, toast_identifier
             )
 
-            if rc == 0:
+            if _flash_write_completed(rc, verification_succeeded):
+                if rc != 0:
+                    log_warn(
+                        f"picotool returned {rc} after verifying the flashed image; "
+                        "treating the write as successful because only the subsequent "
+                        "execute/reconnect step failed."
+                    )
                 _record_flashed_version(board, firmware_version)
                 log_info("Firmware flash succeeded.")
                 if show_toasts:

--- a/src/rov_firmware/websocket/receive/mcu.py
+++ b/src/rov_firmware/websocket/receive/mcu.py
@@ -134,7 +134,7 @@ def _resolve_picotool_path() -> str | None:
 
 
 def _process_flash_output(
-    process: subprocess.Popen[str], toast_identifier: str
+    process: subprocess.Popen[str], toast_identifier: str, show_toasts: bool
 ) -> tuple[int, str, bool]:
     if process.stdout is None:
         return -1, "", False
@@ -150,7 +150,12 @@ def _process_flash_output(
         if output:
             line = output.rstrip()
             all_output.append(line)
-            percent = _update_load_progress(line, percent, toast_identifier)
+            percent = _update_load_progress(
+                line,
+                percent,
+                toast_identifier,
+                show_toasts=show_toasts,
+            )
             verification_reached_100, verification_succeeded = (
                 _update_verification_status(
                     line,
@@ -173,18 +178,25 @@ def _picotool_progress(line: str, prefix: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
-def _update_load_progress(line: str, percent: int, toast_identifier: str) -> int:
+def _update_load_progress(
+    line: str,
+    percent: int,
+    toast_identifier: str,
+    *,
+    show_toasts: bool,
+) -> int:
     new_percent = _picotool_progress(line, "Loading into Flash:")
     if new_percent is None or new_percent == percent:
         return percent
-    toast_loading(
-        identifier=toast_identifier,
-        content=ToastContent(
-            message_key="toasts_flash_in_progress",
-            message_args={"percent": new_percent},
-        ),
-        action=None,
-    )
+    if show_toasts:
+        toast_loading(
+            identifier=toast_identifier,
+            content=ToastContent(
+                message_key="toasts_flash_in_progress",
+                message_args={"percent": new_percent},
+            ),
+            action=None,
+        )
     return new_percent
 
 
@@ -259,7 +271,11 @@ async def flash_mcu_firmware(
             )
             loop = asyncio.get_running_loop()
             rc, output, verification_succeeded = await loop.run_in_executor(
-                None, _process_flash_output, process, toast_identifier
+                None,
+                _process_flash_output,
+                process,
+                toast_identifier,
+                show_toasts,
             )
 
             if _flash_write_completed(rc, verification_succeeded):

--- a/src/rov_firmware/websocket/receive/state.py
+++ b/src/rov_firmware/websocket/receive/state.py
@@ -19,6 +19,15 @@ async def handle_toggle_auto_stabilization(
     log_info(f"Toggled auto stabilization to {state.system_status.auto_stabilization}")
 
 
+async def handle_set_auto_stabilization(state: RovState, enabled: bool) -> None:
+    """Set auto stabilization to the requested state."""
+    state.system_status.auto_stabilization = enabled
+    if not enabled:
+        state.regulator.desired_pitch = 0.0
+        state.regulator.desired_roll = 0.0
+    log_info(f"Set auto stabilization to {enabled}")
+
+
 async def handle_toggle_depth_hold(
     state: RovState,
 ) -> None:
@@ -37,3 +46,16 @@ async def handle_toggle_depth_hold(
     else:
         state.regulator.pending_desired_depth = None
     log_info(f"Toggled depth hold to {state.system_status.depth_hold}")
+
+
+async def handle_set_depth_hold(state: RovState, enabled: bool) -> None:
+    """Set depth hold to the requested state."""
+    if enabled and not state.system_status.depth_hold:
+        pending = state.regulator.pending_desired_depth
+        state.regulator.desired_depth = (
+            pending if pending is not None else state.pressure.depth
+        )
+    if not enabled:
+        state.regulator.pending_desired_depth = None
+    state.system_status.depth_hold = enabled
+    log_info(f"Set depth hold to {enabled}")

--- a/src/rov_firmware/websocket/send/status.py
+++ b/src/rov_firmware/websocket/send/status.py
@@ -1,9 +1,41 @@
 """WebSocket status send handlers for the ROV firmware."""
 
+from ...constants import MOTORS_PER_BUS
+from ...models.config import CurrentSensingMode
 from ...models.rov_status import RovStatus
 from ...rov_state import RovState
 from ...sensors.pi_power import is_pi_undervoltage_detected
 from ..message import StatusUpdate
+
+
+def _current_draw(state: RovState) -> int:
+    """Return total live ESC current in amperes without double-counting buses."""
+    currents = state.mcu_telemetry.current
+    valid = state.mcu_telemetry.current_valid
+
+    if state.rov_config.current_sensing_mode == CurrentSensingMode.PER_MOTOR:
+        return sum(
+            value for value, is_valid in zip(currents, valid, strict=False) if is_valid
+        )
+
+    total = 0.0
+    for start in range(0, len(currents), MOTORS_PER_BUS):
+        bus_currents = [
+            value
+            for value, is_valid in zip(
+                currents[start : start + MOTORS_PER_BUS],
+                valid[start : start + MOTORS_PER_BUS],
+                strict=False,
+            )
+            if is_valid
+        ]
+        if bus_currents:
+            # Every controller on a 4-in-1 ESC reports the same board-level
+            # shunt. Average only fresh copies, then count that bus once.
+            total += sum(bus_currents) / len(bus_currents)
+    # EDT itself has 1 A resolution, so keep the established integer WebSocket
+    # contract and round only after all shared-bus copies have been averaged.
+    return int(total + 0.5)
 
 
 def build_status_update(state: RovState) -> StatusUpdate:
@@ -24,7 +56,7 @@ def build_status_update(state: RovState) -> StatusUpdate:
         if average_voltage_v
         else 0
     )
-    current_draw = sum(state.mcu_telemetry.current)
+    current_draw = _current_draw(state)
 
     payload = RovStatus(
         auto_stabilization=state.system_status.auto_stabilization,

--- a/src/rov_firmware/websocket/types.py
+++ b/src/rov_firmware/websocket/types.py
@@ -23,6 +23,8 @@ class MessageType(StrEnum):
     CUSTOM_ACTION = "customAction"
     TOGGLE_AUTO_STABILIZATION = "toggleAutoStabilization"
     TOGGLE_DEPTH_HOLD = "toggleDepthHold"
+    SET_AUTO_STABILIZATION = "setAutoStabilization"
+    SET_DEPTH_HOLD = "setDepthHold"
     SET_DESIRED_DEPTH = "setDesiredDepth"
     FLASH_MCU_FIRMWARE = "flashMcuFirmware"
     FLASH_ESC_FIRMWARE = "flashEscFirmware"

--- a/src/tools/mock_websocket_server.py
+++ b/src/tools/mock_websocket_server.py
@@ -603,8 +603,14 @@ async def _handle_client(websocket: ServerConnection) -> None:  # noqa: C901,PLR
                     config_msg = {"type": "config", "payload": MOCK_CONFIG}
                     await websocket.send(json.dumps(config_msg))
                 elif msg_type == "setConfig":
+                    previous_connection = (
+                        MOCK_CONFIG.get("ipAddress"),
+                        MOCK_CONFIG.get("websocketPort"),
+                    )
                     if isinstance(payload, dict):
                         _update_mock_config(cast(dict[str, Any], payload))
+                    config_msg = {"type": "config", "payload": MOCK_CONFIG}
+                    await websocket.send(json.dumps(config_msg))
                     toast_msg = {
                         "type": "showToast",
                         "payload": {
@@ -619,6 +625,15 @@ async def _handle_client(websocket: ServerConnection) -> None:  # noqa: C901,PLR
                         },
                     }
                     await websocket.send(json.dumps(toast_msg))
+                    current_connection = (
+                        MOCK_CONFIG.get("ipAddress"),
+                        MOCK_CONFIG.get("websocketPort"),
+                    )
+                    if current_connection != previous_connection:
+                        await websocket.close(
+                            reason="Mock ROV connection settings changed"
+                        )
+                        return
                 elif msg_type == "importConfig":
                     if isinstance(payload, dict):
                         _update_mock_config(
@@ -653,6 +668,17 @@ async def _handle_client(websocket: ServerConnection) -> None:  # noqa: C901,PLR
                         },
                     }
                     await websocket.send(json.dumps(log_msg))
+                elif msg_type == "setAutoStabilization":
+                    SYSTEM_STATUS["autoStabilization"] = bool(payload)
+                    log_msg = {
+                        "type": "logMessage",
+                        "payload": {
+                            "origin": "firmware",
+                            "level": "info",
+                            "message": f"Auto stabilization set to {SYSTEM_STATUS['autoStabilization']}",
+                        },
+                    }
+                    await websocket.send(json.dumps(log_msg))
                 elif msg_type == "toggleDepthHold":
                     SYSTEM_STATUS["depthHold"] = not SYSTEM_STATUS["depthHold"]
                     if SYSTEM_STATUS["depthHold"]:
@@ -666,6 +692,29 @@ async def _handle_client(websocket: ServerConnection) -> None:  # noqa: C901,PLR
                             )
                     else:
                         SYSTEM_STATUS["pendingDesiredDepth"] = None
+                    log_msg = {
+                        "type": "logMessage",
+                        "payload": {
+                            "origin": "firmware",
+                            "level": "info",
+                            "message": f"Depth hold set to {SYSTEM_STATUS['depthHold']}",
+                        },
+                    }
+                    await websocket.send(json.dumps(log_msg))
+                elif msg_type == "setDepthHold":
+                    enabled = bool(payload)
+                    if enabled and not SYSTEM_STATUS["depthHold"]:
+                        pending = SYSTEM_STATUS["pendingDesiredDepth"]
+                        if pending is not None:
+                            SYSTEM_STATUS["desiredDepth"] = pending
+                        else:
+                            current_time = time.time()
+                            SYSTEM_STATUS["desiredDepth"] = 10 + 5 * math.sin(
+                                current_time / 4
+                            )
+                    if not enabled:
+                        SYSTEM_STATUS["pendingDesiredDepth"] = None
+                    SYSTEM_STATUS["depthHold"] = enabled
                     log_msg = {
                         "type": "logMessage",
                         "payload": {

--- a/tests/test_import_config.py
+++ b/tests/test_import_config.py
@@ -158,7 +158,9 @@ def test_import_restarts_firmware_when_websocket_port_changed(rov_state, monkeyp
     assert restart_calls == [None]
 
 
-def test_import_applies_network_once_when_ip_and_port_changed(rov_state, monkeypatch):
+def test_import_applies_network_then_restarts_when_ip_and_port_changed(
+    rov_state, monkeypatch
+):
     network_calls: list[str] = []
     restart_calls: list[None] = []
 
@@ -178,4 +180,4 @@ def test_import_applies_network_once_when_ip_and_port_changed(rov_state, monkeyp
     asyncio.run(handle_import_config(rov_state, payload))
 
     assert network_calls == ["10.10.11.10"]
-    assert restart_calls == []
+    assert restart_calls == [None]

--- a/tests/test_mcu_flash.py
+++ b/tests/test_mcu_flash.py
@@ -96,3 +96,38 @@ def test_verification_requires_complete_progress_followed_by_ok():
     )
     assert reached_100
     assert succeeded
+
+
+def test_load_progress_is_tracked_without_a_toast_when_hidden(monkeypatch):
+    toast_calls: list[None] = []
+    monkeypatch.setattr(
+        mcu, "toast_loading", lambda **_kwargs: toast_calls.append(None)
+    )
+
+    percent = mcu._update_load_progress(
+        "Loading into Flash: [===============] 50%",
+        0,
+        "firmware-flash",
+        show_toasts=False,
+    )
+
+    assert percent == 50
+    assert toast_calls == []
+
+
+def test_load_progress_emits_a_toast_when_visible(monkeypatch):
+    toast_calls: list[dict] = []
+    monkeypatch.setattr(
+        mcu, "toast_loading", lambda **kwargs: toast_calls.append(kwargs)
+    )
+
+    percent = mcu._update_load_progress(
+        "Loading into Flash: [===============] 50%",
+        0,
+        "firmware-flash",
+        show_toasts=True,
+    )
+
+    assert percent == 50
+    assert len(toast_calls) == 1
+    assert toast_calls[0]["identifier"] == "firmware-flash"

--- a/tests/test_mcu_flash.py
+++ b/tests/test_mcu_flash.py
@@ -66,3 +66,33 @@ def test_unmarked_matching_stable_does_not_flash(tmp_path, monkeypatch):
     (tmp_path / "mcu-firmware").mkdir()
 
     assert not mcu.mcu_update_required(McuBoard.PICO2, "1.0.3", "1.0.3")
+
+
+def test_verified_picotool_write_survives_execute_failure():
+    assert mcu._flash_write_completed(return_code=1, verification_succeeded=True)
+
+
+def test_successful_picotool_exit_does_not_need_fallback():
+    assert mcu._flash_write_completed(return_code=0, verification_succeeded=False)
+
+
+def test_unverified_picotool_write_remains_a_failure():
+    assert not mcu._flash_write_completed(return_code=1, verification_succeeded=False)
+
+
+def test_verification_requires_complete_progress_followed_by_ok():
+    reached_100, succeeded = mcu._update_verification_status(
+        "Verifying Flash: [==============================] 100%",
+        reached_100=False,
+        succeeded=False,
+    )
+    assert reached_100
+    assert not succeeded
+
+    reached_100, succeeded = mcu._update_verification_status(
+        "  OK",
+        reached_100=reached_100,
+        succeeded=succeeded,
+    )
+    assert reached_100
+    assert succeeded

--- a/tests/test_mcu_sensor.py
+++ b/tests/test_mcu_sensor.py
@@ -82,7 +82,26 @@ def test_signal_quality_updates_do_not_keep_stale_current_alive(rov_state, monke
     sensor._expire_stale_telemetry()
 
     assert rov_state.mcu_telemetry.current[0] == 0
+    assert rov_state.mcu_telemetry.current_valid[0] is False
     assert rov_state.mcu_telemetry.signal_quality[0] == 100
+
+
+def test_current_telemetry_preserves_raw_edt_amperes(rov_state):
+    sensor = McuSensor(rov_state, SerialManager(rov_state))
+
+    sensor._update_telemetry_item(2, MCU_TELEMETRY_TYPE_CURRENT, 3)
+
+    assert rov_state.mcu_telemetry.current[2] == 3
+    assert rov_state.mcu_telemetry.current_valid[2] is True
+
+
+def test_current_telemetry_rejects_negative_usb_values(rov_state):
+    sensor = McuSensor(rov_state, SerialManager(rov_state))
+
+    sensor._update_telemetry_item(2, MCU_TELEMETRY_TYPE_CURRENT, -1)
+
+    assert rov_state.mcu_telemetry.current[2] == 0
+    assert rov_state.mcu_telemetry.current_valid[2] is True
 
 
 def test_esc_firmware_version_is_assembled_from_live_telemetry(rov_state, monkeypatch):

--- a/tests/test_mcu_sensor.py
+++ b/tests/test_mcu_sensor.py
@@ -16,6 +16,21 @@ from rov_firmware.sensors.mcu import McuSensor
 from rov_firmware.serial import SerialManager
 
 
+class _CompletedTask:
+    def done(self) -> bool:
+        return True
+
+
+class _RecordingLoop:
+    def __init__(self) -> None:
+        self.created = 0
+
+    def create_task(self, coroutine) -> _CompletedTask:
+        self.created += 1
+        coroutine.close()
+        return _CompletedTask()
+
+
 def _version_packet(protocol: int, dshot_speed: int) -> bytes:
     packet = bytearray(
         [
@@ -69,6 +84,43 @@ def test_version_packet_does_not_reflash_matching_prerelease_bundle(
     sensor._handle_version_packet(_version_packet(MCU_PROTOCOL_DSHOT, 600))
 
     assert rov_state.device_info.mcu_firmware_version == "1.2.3"
+
+
+def test_version_mismatch_auto_flashes_only_once_per_service_start(
+    rov_state, monkeypatch
+):
+    loop = _RecordingLoop()
+    sensor = McuSensor(rov_state, SerialManager(rov_state))
+    monkeypatch.setattr(mcu_module.asyncio, "get_running_loop", lambda: loop)
+    monkeypatch.setattr(mcu_module, "mcu_update_required", lambda *_args: True)
+
+    sensor._auto_update_mcu_if_needed("1.2.2", "1.2.3")
+    sensor._auto_update_mcu_if_needed("1.2.2", "1.2.3")
+
+    assert loop.created == 1
+    assert sensor._mcu_auto_flash_attempted is True
+
+
+def test_esc_mismatch_auto_flashes_only_once_per_service_start(rov_state, monkeypatch):
+    loop = _RecordingLoop()
+    sensor = McuSensor(rov_state, SerialManager(rov_state))
+    monkeypatch.setattr(mcu_module.asyncio, "get_running_loop", lambda: loop)
+    monkeypatch.setattr(
+        mcu_module,
+        "resolve_esc_firmware",
+        lambda: (Path("esc-v2.21.0.bin"), "2.21.0"),
+    )
+    monkeypatch.setattr(
+        mcu_module,
+        "esc_firmware_update_required",
+        lambda *_args: True,
+    )
+
+    sensor._auto_update_esc_firmware_if_needed()
+    sensor._auto_update_esc_firmware_if_needed()
+
+    assert loop.created == 1
+    assert sensor._esc_auto_flash_attempted is True
 
 
 def test_signal_quality_updates_do_not_keep_stale_current_alive(rov_state, monkeypatch):

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -142,7 +142,7 @@ def test_set_config_restarts_firmware_when_websocket_port_changed(
     assert restart_calls == [None]
 
 
-def test_set_config_applies_network_once_when_ip_and_port_changed(
+def test_set_config_applies_network_then_restarts_when_ip_and_port_changed(
     rov_state, monkeypatch
 ):
     network_calls: list[str] = []
@@ -166,7 +166,35 @@ def test_set_config_applies_network_once_when_ip_and_port_changed(
     asyncio.run(handle_set_config(rov_state, payload))
 
     assert network_calls == ["10.10.11.10"]
-    assert restart_calls == []
+    assert restart_calls == [None]
+
+
+def test_set_config_rolls_back_ip_and_port_when_combined_restart_fails(
+    rov_state, monkeypatch
+):
+    network_calls: list[str] = []
+
+    def apply_ip_address(ip_address: str) -> bool:
+        network_calls.append(ip_address)
+        return True
+
+    async def restart_firmware() -> bool:
+        return False
+
+    monkeypatch.setattr(config_handlers, "_apply_ip_address", apply_ip_address)
+    monkeypatch.setattr(config_handlers, "_restart_firmware", restart_firmware)
+
+    payload = PartialRovConfig.model_validate(
+        {"ipAddress": "10.10.11.10", "websocketPort": 9100}
+    )
+    asyncio.run(handle_set_config(rov_state, payload))
+
+    assert network_calls == ["10.10.11.10", "10.10.10.10"]
+    assert rov_state.rov_config.ip_address == "10.10.10.10"
+    assert rov_state.rov_config.websocket_port == 9000
+    persisted = RovConfig.load()
+    assert persisted.ip_address == "10.10.10.10"
+    assert persisted.websocket_port == 9000
 
 
 def test_set_config_reports_network_apply_failure_without_success(

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -174,7 +174,13 @@ def test_set_config_reports_network_apply_failure_without_success(
 ):
     success_calls: list[None] = []
     warning_keys: list[str] = []
-    monkeypatch.setattr(config_handlers, "_apply_ip_address", lambda _address: False)
+    network_calls: list[str] = []
+
+    def apply_ip_address(address: str) -> bool:
+        network_calls.append(address)
+        return False
+
+    monkeypatch.setattr(config_handlers, "_apply_ip_address", apply_ip_address)
     monkeypatch.setattr(
         config_handlers,
         "toast_success",
@@ -191,6 +197,9 @@ def test_set_config_reports_network_apply_failure_without_success(
 
     assert success_calls == []
     assert warning_keys == ["toasts_rov_connection_restart_failed"]
+    assert network_calls == ["10.10.11.10", "10.10.10.10"]
+    assert rov_state.rov_config.ip_address == "10.10.10.10"
+    assert RovConfig.load().ip_address == "10.10.10.10"
 
 
 def test_set_config_reports_restart_failure_without_success(rov_state, monkeypatch):
@@ -217,3 +226,5 @@ def test_set_config_reports_restart_failure_without_success(rov_state, monkeypat
 
     assert success_calls == []
     assert warning_keys == ["toasts_rov_connection_restart_failed"]
+    assert rov_state.rov_config.websocket_port == 9000
+    assert RovConfig.load().websocket_port == 9000

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,3 +1,4 @@
+from rov_firmware.models.config import CurrentSensingMode
 from rov_firmware.websocket.send import status
 
 
@@ -18,3 +19,51 @@ def test_status_reports_read_only_device_versions(rov_state):
 
     assert payload["deviceInfo"]["mcuFirmwareVersion"] == "1.2.3-rc.1"
     assert payload["deviceInfo"]["escFirmwareVersions"] == ["2.20.0-rc.3"] * 8
+
+
+def test_status_counts_each_shared_current_bus_once(rov_state):
+    rov_state.rov_config.current_sensing_mode = CurrentSensingMode.SHARED_BUS
+    rov_state.mcu_telemetry.current = [3, 3, 3, 3, 7, 7, 7, 7]
+    rov_state.mcu_telemetry.current_valid = [True] * 8
+
+    payload = status.build_status_update(rov_state).payload
+
+    assert payload.current_draw == 10
+
+
+def test_status_averages_only_fresh_shared_bus_readings(rov_state):
+    rov_state.rov_config.current_sensing_mode = CurrentSensingMode.SHARED_BUS
+    rov_state.mcu_telemetry.current = [2, 3, 0, 0, 8, 0, 0, 0]
+    rov_state.mcu_telemetry.current_valid = [
+        True,
+        True,
+        False,
+        False,
+        True,
+        False,
+        False,
+        False,
+    ]
+
+    payload = status.build_status_update(rov_state).payload
+
+    assert payload.current_draw == 11
+
+
+def test_status_sums_fresh_per_motor_current(rov_state):
+    rov_state.rov_config.current_sensing_mode = CurrentSensingMode.PER_MOTOR
+    rov_state.mcu_telemetry.current = [1, 2, 3, 4, 5, 6, 7, 8]
+    rov_state.mcu_telemetry.current_valid = [
+        True,
+        True,
+        False,
+        True,
+        True,
+        True,
+        True,
+        True,
+    ]
+
+    payload = status.build_status_update(rov_state).payload
+
+    assert payload.current_draw == 33

--- a/tests/test_websocket_state.py
+++ b/tests/test_websocket_state.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from rov_firmware.websocket.receive.state import (
+    handle_set_auto_stabilization,
+    handle_set_depth_hold,
+)
+
+
+def test_auto_stabilization_set_is_idempotent(rov_state):
+    rov_state.system_status.auto_stabilization = True
+    rov_state.regulator.desired_pitch = 12.0
+    rov_state.regulator.desired_roll = -8.0
+
+    asyncio.run(handle_set_auto_stabilization(rov_state, True))
+
+    assert rov_state.system_status.auto_stabilization is True
+    assert rov_state.regulator.desired_pitch == 12.0
+    assert rov_state.regulator.desired_roll == -8.0
+
+    asyncio.run(handle_set_auto_stabilization(rov_state, False))
+
+    assert rov_state.system_status.auto_stabilization is False
+    assert rov_state.regulator.desired_pitch == 0.0
+    assert rov_state.regulator.desired_roll == 0.0
+
+
+def test_depth_hold_set_only_captures_depth_on_enable_transition(rov_state):
+    rov_state.pressure.depth = 7.5
+
+    asyncio.run(handle_set_depth_hold(rov_state, True))
+    assert rov_state.system_status.depth_hold is True
+    assert rov_state.regulator.desired_depth == 7.5
+
+    rov_state.pressure.depth = 11.0
+    asyncio.run(handle_set_depth_hold(rov_state, True))
+    assert rov_state.regulator.desired_depth == 7.5
+
+    asyncio.run(handle_set_depth_hold(rov_state, False))
+    assert rov_state.system_status.depth_hold is False
+    assert rov_state.regulator.pending_desired_depth is None


### PR DESCRIPTION
## Summary\n\n- add explicit idempotent stabilization and depth-hold setters while retaining legacy toggle compatibility\n- make network changes transactional with rollback when the new address cannot be applied\n- verify MCU flashes and treat a verified image as success even when the flashing tool exits noisily\n- prevent repeated automatic MCU and ESC flashing during one service start\n- aggregate shared ESC-bus current once and reject stale telemetry\n- bundle ESC firmware v2.21.0-rc.1\n\n## Release ordering\n\nThe published v2.21.0-rc.1 ESC artifact is locked into flake.lock by content hash. Merge and release this firmware before the app PR.\n\n## Validation\n\n- Ruff passes\n- ty passes\n- 192 tests pass\n- Nix flake checks and Pi image evaluation pass