### PR TITLE
chore(release): v1.1.6-rc.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.1.6-rc.4"
+version = "1.1.6-rc.5"
 description = "Firmware for the Manafish ROV"
 license = "AGPL-3.0-or-later"
 requires-python = "==3.13.14"

--- a/uv.lock
+++ b/uv.lock
@@ -109,7 +109,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/56/33/26ec2e8049eaa2f07
 
 [[package]]
 name = "manafish"
-version = "1.1.6rc4"
+version = "1.1.6rc5"
 source = { editable = "." }
 dependencies = [
     { name = "bmi270" },


### PR DESCRIPTION
## Release candidate

Bumps the Pi firmware package version for the field-test follow-up release.

Includes explicit stabilization state synchronization, transactional network changes, hardened MCU/ESC flashing, corrected current aggregation, and the bundled ESC firmware v2.21.0-rc.1 artifact.

Validation: Ruff, ty, and 192 tests pass; the feature PR also passed Nix formatting and evaluation checks.