### PR TITLE
chore(release): v1.1.6-rc.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,13 +35,13 @@
     "esc-firmware": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-mgGjBMSjAyC5FG73i2loPbhlYaOcXPIubgqQd7cRpQk=",
+        "narHash": "sha256-A6ZJtmU5IFrZ5C7ycFpYjHfkcwiX13L+3PD5wZxQz7Y=",
         "type": "file",
-        "url": "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.1/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin"
+        "url": "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.2/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.1/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin"
+        "url": "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.2/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin"
       }
     },
     "flake-compat": {
@@ -104,25 +104,25 @@
     "mcu-firmware-pico": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-8lEUx/J16Ecwc7dp1miR32pb0BfFU/60fgUIEqQECVY=",
+        "narHash": "sha256-SG0mPPGYTBVBkLECNpLb599L1x6WwYoIyy8QE9GCcC4=",
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.2/pico-v1.0.3-rc.2.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico-v1.0.3-rc.3.uf2"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.2/pico-v1.0.3-rc.2.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico-v1.0.3-rc.3.uf2"
       }
     },
     "mcu-firmware-pico2": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-/R3fn90UsFnN5E84oiBirqfJEZWzICvAGXixJUBtvH0=",
+        "narHash": "sha256-GE35xOV/MBjoCcp////0/ttGGex1JoslFXRagoaXRpw=",
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.2/pico2-v1.0.3-rc.2.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico2-v1.0.3-rc.3.uf2"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.2/pico2-v1.0.3-rc.2.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico2-v1.0.3-rc.3.uf2"
       }
     },
     "ms5837-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,15 +40,15 @@
       flake = false;
     };
     mcu-firmware-pico = {
-      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.2/pico-v1.0.3-rc.2.uf2";
+      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico-v1.0.3-rc.3.uf2";
       flake = false;
     };
     mcu-firmware-pico2 = {
-      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.2/pico2-v1.0.3-rc.2.uf2";
+      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico2-v1.0.3-rc.3.uf2";
       flake = false;
     };
     esc-firmware = {
-      url = "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.1/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin";
+      url = "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.2/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin";
       flake = false;
     };
   };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.1.6-rc.5"
+version = "1.1.6-rc.6"
 description = "Firmware for the Manafish ROV"
 license = "AGPL-3.0-or-later"
 requires-python = "==3.13.14"

--- a/uv.lock
+++ b/uv.lock
@@ -109,7 +109,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/56/33/26ec2e8049eaa2f07
 
 [[package]]
 name = "manafish"
-version = "1.1.6rc5"
+version = "1.1.6rc6"
 source = { editable = "." }
 dependencies = [
     { name = "bmi270" },


### PR DESCRIPTION
Prepare Pi firmware `v1.1.6-rc.6` with the exact MCU and ESC artifacts produced by this release sequence.

- bump the Pi firmware package version to `1.1.6-rc.6`
- bundle MCU firmware `v1.0.3-rc.3` for Pico and Pico 2
- bundle ESC firmware `v2.21.0-rc.2`
- lock each downloaded artifact to its evaluated Nix hash

Verification:
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` (211 tests)
- `nix fmt -- --ci .`
- `nix flake check --show-trace`
- `nix build --accept-flake-config --dry-run`

---
Generated by UNKNOWN-MODEL using the Codex harness.