### PR TITLE
fix(mcu): make thruster tests readiness-aware

### DIFF
--- a/src/rov_firmware/models/rov_status.py
+++ b/src/rov_firmware/models/rov_status.py
@@ -12,6 +12,7 @@ class RovStatus(CamelCaseModel):
     battery_percentage: int
     current_draw: int
     pi_undervoltage: bool
+    thruster_control_ready: bool
     health: SystemHealth
     device_info: DeviceInfo
     esc_firmware_update: EscFirmwareUpdate

--- a/src/rov_firmware/models/rov_telemetry.py
+++ b/src/rov_firmware/models/rov_telemetry.py
@@ -17,5 +17,5 @@ class RovTelemetry(CamelCaseModel):
     water_temperature: float
     electronics_temperature: float
     thruster_rpms: list[int]
-    thruster_signal_qualities: list[float]
+    thruster_signal_qualities: list[float | None]
     work_indicator_percentage: int

--- a/src/rov_firmware/models/sensors.py
+++ b/src/rov_firmware/models/sensors.py
@@ -16,6 +16,16 @@ class McuData(BaseModel):
     voltage: list[float] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     temperature: list[int] = [0, 0, 0, 0, 0, 0, 0, 0]
     signal_quality: list[float] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    signal_quality_valid: list[bool] = [
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    ]
 
 
 class ImuData(BaseModel):

--- a/src/rov_firmware/models/system.py
+++ b/src/rov_firmware/models/system.py
@@ -62,3 +62,4 @@ class SystemStatus(BaseModel):
     auto_stabilization: bool = False
     depth_hold: bool = False
     battery_percentage: float = 0
+    thruster_control_ready: bool = False

--- a/src/rov_firmware/models/thruster.py
+++ b/src/rov_firmware/models/thruster.py
@@ -17,5 +17,6 @@ class ThrusterData(CamelCaseModel):
     work_indicator_percentage: int = 0
     last_direction_time: float = 0.0
     test_thruster: int | None = None
+    test_request_id: int = 0
     test_start_time: float | None = None
     last_remaining: int = 0

--- a/src/rov_firmware/models/thruster.py
+++ b/src/rov_firmware/models/thruster.py
@@ -17,5 +17,5 @@ class ThrusterData(CamelCaseModel):
     work_indicator_percentage: int = 0
     last_direction_time: float = 0.0
     test_thruster: int | None = None
-    test_start_time: float = 0.0
-    last_remaining: int = 10
+    test_start_time: float | None = None
+    last_remaining: int = 0

--- a/src/rov_firmware/sensors/mcu.py
+++ b/src/rov_firmware/sensors/mcu.py
@@ -133,11 +133,11 @@ class McuSensor:
         read_buffer = bytearray()
         while True:
             data = await self._read_chunk()
+            self._expire_stale_telemetry()
             if data is None:
                 await asyncio.sleep(1)
                 continue
             self._consume_read_buffer(read_buffer, data)
-            self._expire_stale_telemetry()
 
     async def shutdown(self) -> None:
         """Cancel MCU-owned ESC tasks before the serial connection closes."""
@@ -587,6 +587,8 @@ class McuSensor:
         getattr(self.state.mcu_telemetry, field)[global_id] = 0
         if packet_type == MCU_TELEMETRY_TYPE_CURRENT:
             self.state.mcu_telemetry.current_valid[global_id] = False
+        elif packet_type == MCU_TELEMETRY_TYPE_SIGNAL_QUALITY:
+            self.state.mcu_telemetry.signal_quality_valid[global_id] = False
         self._last_telemetry_time[global_id][packet_type] = 0.0
 
     def _update_telemetry(self, packet: bytes | bytearray | memoryview) -> None:
@@ -634,6 +636,7 @@ class McuSensor:
                 self.state.mcu_telemetry.current_valid[global_id] = True
             elif packet_type == MCU_TELEMETRY_TYPE_SIGNAL_QUALITY:
                 self.state.mcu_telemetry.signal_quality[global_id] = value / 100
+                self.state.mcu_telemetry.signal_quality_valid[global_id] = True
 
     def _update_esc_firmware_version(
         self, global_id: int, packet_type: int, value: int

--- a/src/rov_firmware/serial.py
+++ b/src/rov_firmware/serial.py
@@ -47,6 +47,7 @@ class SerialManager:
         self.reader = None
         self.writer = None
         self._mcu_protocol_config = None
+        self.state.system_status.thruster_control_ready = False
         self.state.device_info.mcu_firmware_version = ""
         self.state.system_health.mcu_healthy = False
         if writer is not None:
@@ -89,6 +90,7 @@ class SerialManager:
                 )
                 self._connection_generation += 1
                 self._mcu_protocol_config = None
+                self.state.system_status.thruster_control_ready = False
                 self.state.system_health.mcu_healthy = True
                 log_info("MCU initialized successfully.")
                 return True
@@ -160,8 +162,15 @@ class SerialManager:
         return self._mcu_protocol_config
 
     def record_mcu_protocol_config(self, protocol: str, dshot_speed: int) -> None:
-        """Record a protocol configuration reported by an MCU version packet."""
+        """Record a protocol configuration acknowledged by the MCU."""
         self._mcu_protocol_config = (protocol, dshot_speed)
+        desired = (
+            self.state.rov_config.thruster_protocol.value,
+            self.state.rov_config.dshot_speed,
+        )
+        self.state.system_status.thruster_control_ready = (
+            self._mcu_protocol_config == desired
+        )
 
     async def shutdown(self) -> None:
         """Shutdown the serial connection."""

--- a/src/rov_firmware/thrusters.py
+++ b/src/rov_firmware/thrusters.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from asyncio import StreamWriter
+import math
 import struct
 import time
 from typing import cast
@@ -464,9 +465,17 @@ class Thrusters:
     def _handle_thruster_test(
         self, current_time: float, test_thruster: int
     ) -> NDArray[np.float32] | None:
-        elapsed = current_time - self.state.thrusters.test_start_time
+        start_time = self.state.thrusters.test_start_time
+        if start_time is None:
+            thrust_vector = self._test_thrust_vector
+            thrust_vector.fill(0.0)
+            thrust_vector[test_thruster] = 0.1
+            return thrust_vector
+
+        elapsed = current_time - start_time
         if elapsed >= THRUSTER_TEST_DURATION_SECONDS:
             self.state.thrusters.test_thruster = None
+            self.state.thrusters.test_start_time = None
             toast_content(
                 identifier=THRUSTER_TEST_TOAST_ID,
                 variant=ToastVariant.SUCCESS,
@@ -480,7 +489,7 @@ class Thrusters:
             thrust_vector = self._test_thrust_vector
             thrust_vector.fill(0.0)
             thrust_vector[test_thruster] = 0.1
-            remaining = int(THRUSTER_TEST_DURATION_SECONDS - elapsed)
+            remaining = math.ceil(THRUSTER_TEST_DURATION_SECONDS - elapsed)
             if remaining != self.state.thrusters.last_remaining:
                 self.state.thrusters.last_remaining = remaining
                 toast_content(
@@ -495,6 +504,42 @@ class Thrusters:
                     action=cancel_thruster_test_action(test_thruster),
                 )
             return thrust_vector
+
+    def _mark_thruster_test_started(self, current_time: float) -> None:
+        """Start the countdown after the first test command was written."""
+        test_thruster = self.state.thrusters.test_thruster
+        if test_thruster is None or self.state.thrusters.test_start_time is not None:
+            return
+        self.state.thrusters.test_start_time = current_time
+        self.state.thrusters.last_remaining = THRUSTER_TEST_DURATION_SECONDS
+        toast_content(
+            identifier=THRUSTER_TEST_TOAST_ID,
+            variant=ToastVariant.LOADING,
+            content=ToastContent(
+                message_key="toasts_thruster_test_title",
+                message_args={"thruster": test_thruster},
+                description_key="toasts_seconds_remaining",
+                description_args={"seconds": THRUSTER_TEST_DURATION_SECONDS},
+            ),
+            action=cancel_thruster_test_action(test_thruster),
+        )
+
+    def _fail_thruster_test_unavailable(self) -> None:
+        """End an active or queued test when motor output is unavailable."""
+        if self.state.thrusters.test_thruster is None:
+            return
+        self.state.thrusters.test_thruster = None
+        self.state.thrusters.test_start_time = None
+        self.state.thrusters.last_remaining = 0
+        toast_content(
+            identifier=THRUSTER_TEST_TOAST_ID,
+            variant=ToastVariant.ERROR,
+            content=ToastContent(
+                message_key="toasts_thruster_test_unavailable",
+                description_key="toasts_thruster_test_unavailable_description",
+            ),
+            action=None,
+        )
 
     async def _send_packet(
         self, writer: StreamWriter, thrust_values: list[int]
@@ -536,12 +581,15 @@ class Thrusters:
             self._pending_config_generation = -1
             self._pending_config_since = 0.0
             self._pending_config_warning_logged = False
+            self.state.system_status.thruster_control_ready = True
             return True
 
         # A protocol change is only safe while the Pico's last accepted motor
-        # command is neutral. Hold neutral until its version packet confirms
+        # command is neutral. Hold neutral until its status packet confirms
         # the requested configuration, and retry if either packet was lost or
         # rejected.
+        self.state.system_status.thruster_control_ready = False
+        self._fail_thruster_test_unavailable()
         await self._send_packet(writer, [THRUSTER_NEUTRAL_PULSE_WIDTH] * NUM_MOTORS)
 
         now = time.monotonic()
@@ -559,7 +607,7 @@ class Thrusters:
         ):
             log_error(
                 "Thruster protocol change is still blocked because the MCU has not "
-                "confirmed it. Check power and telemetry for every ESC."
+                "confirmed it. Check the MCU connection and firmware."
             )
             self._pending_config_warning_logged = True
 
@@ -633,6 +681,8 @@ class Thrusters:
         next_tick = time.perf_counter() + interval
         while True:
             if not await self.serial_manager.ensure_connection():
+                self.state.system_status.thruster_control_ready = False
+                self._fail_thruster_test_unavailable()
                 await asyncio.sleep(1)
                 next_tick = time.perf_counter() + interval
                 continue
@@ -666,10 +716,14 @@ class Thrusters:
 
             thrust_values = self._compute_thrust_values(thrust_vector)
             success = await self._send_with_retries(writer, thrust_values)
-            if not success:
+            if success:
+                self._mark_thruster_test_started(time.time())
+            else:
                 await self.serial_manager.handle_connection_lost(
                     "Thruster send failed 3 times, disabling MCU"
                 )
+                self.state.system_status.thruster_control_ready = False
+                self._fail_thruster_test_unavailable()
 
             sleep_time = next_tick - time.perf_counter()
             await asyncio.sleep(max(0.0, sleep_time))

--- a/src/rov_firmware/thrusters.py
+++ b/src/rov_firmware/thrusters.py
@@ -505,10 +505,17 @@ class Thrusters:
                 )
             return thrust_vector
 
-    def _mark_thruster_test_started(self, current_time: float) -> None:
+    def _mark_thruster_test_started(
+        self, current_time: float, test_request_id: int | None
+    ) -> None:
         """Start the countdown after the first test command was written."""
         test_thruster = self.state.thrusters.test_thruster
-        if test_thruster is None or self.state.thrusters.test_start_time is not None:
+        if (
+            test_request_id is None
+            or test_request_id != self.state.thrusters.test_request_id
+            or test_thruster is None
+            or self.state.thrusters.test_start_time is not None
+        ):
             return
         self.state.thrusters.test_start_time = current_time
         self.state.thrusters.last_remaining = THRUSTER_TEST_DURATION_SECONDS
@@ -626,7 +633,7 @@ class Thrusters:
 
     def _determine_thrust_vector(
         self, current_time: float, last_send_time: float
-    ) -> tuple[NDArray[np.float32] | None, float]:
+    ) -> tuple[NDArray[np.float32] | None, float, int | None]:
         if self.state.regulator.auto_tuning_active:
             tuning_vector = self.regulator.handle_auto_tuning(current_time)
             if tuning_vector is not None:
@@ -638,28 +645,29 @@ class Thrusters:
                 self._reorder_thrust_vector(thrust_vector)
                 self._clip_thrust_vector(thrust_vector)
                 self.state.thrusters.work_indicator_percentage = 0
-                return thrust_vector, last_send_time
+                return thrust_vector, last_send_time, None
 
         if self.state.thrusters.test_thruster is not None:
+            test_request_id = self.state.thrusters.test_request_id
             test_vector = self._handle_thruster_test(
                 current_time, self.state.thrusters.test_thruster
             )
             if test_vector is not None:
                 self.state.thrusters.work_indicator_percentage = 0
-                return test_vector, last_send_time
+                return test_vector, last_send_time, test_request_id
 
         if (
             self.state.thrusters.last_direction_time > 0
             and current_time - self.state.thrusters.last_direction_time
             < THRUSTER_TIMEOUT_MS / 1000
         ):
-            return self._create_thrust_vector(), current_time
+            return self._create_thrust_vector(), current_time, None
 
         if current_time - last_send_time > THRUSTER_TIMEOUT_MS / 1000:
             self.state.thrusters.work_indicator_percentage = 0
-            return self._zero_thrust_vector, last_send_time
+            return self._zero_thrust_vector, last_send_time, None
 
-        return None, last_send_time
+        return None, last_send_time, None
 
     async def _send_with_retries(
         self, writer: StreamWriter, thrust_values: list[int]
@@ -707,9 +715,11 @@ class Thrusters:
                 continue
 
             current_time = time.time()
-            new_thrust_vector, updated_last_send_time = self._determine_thrust_vector(
-                current_time, last_send_time
-            )
+            (
+                new_thrust_vector,
+                updated_last_send_time,
+                test_request_id,
+            ) = self._determine_thrust_vector(current_time, last_send_time)
             if new_thrust_vector is not None:
                 thrust_vector = new_thrust_vector
                 last_send_time = updated_last_send_time
@@ -717,7 +727,7 @@ class Thrusters:
             thrust_values = self._compute_thrust_values(thrust_vector)
             success = await self._send_with_retries(writer, thrust_values)
             if success:
-                self._mark_thruster_test_started(time.time())
+                self._mark_thruster_test_started(time.time(), test_request_id)
             else:
                 await self.serial_manager.handle_connection_lost(
                     "Thruster send failed 3 times, disabling MCU"

--- a/src/rov_firmware/websocket/receive/actions.py
+++ b/src/rov_firmware/websocket/receive/actions.py
@@ -9,7 +9,7 @@ from ...models.actions import CustomAction, DirectionVector
 from ...models.config import ThrusterTest
 from ...models.toast import ToastVariant
 from ...rov_state import RovState
-from ...toast import ToastContent, cancel_thruster_test_action, toast_content
+from ...toast import ToastContent, toast_content
 
 
 async def handle_direction_vector(
@@ -36,21 +36,23 @@ async def handle_start_thruster_test(
         state: The ROV state.
         payload: The thruster test index.
     """
-    log_info(f"Starting thruster test: {payload}")
+    if not state.system_status.thruster_control_ready:
+        log_warn(f"Rejecting thruster test {payload}: thruster control is not ready")
+        toast_content(
+            identifier=THRUSTER_TEST_TOAST_ID,
+            variant=ToastVariant.ERROR,
+            content=ToastContent(
+                message_key="toasts_thruster_test_unavailable",
+                description_key="toasts_thruster_test_unavailable_description",
+            ),
+            action=None,
+        )
+        return
+
+    log_info(f"Queueing thruster test: {payload}")
     state.thrusters.test_thruster = payload
-    state.thrusters.test_start_time = time.time()
-    state.thrusters.last_remaining = 10
-    toast_content(
-        identifier=THRUSTER_TEST_TOAST_ID,
-        variant=ToastVariant.LOADING,
-        content=ToastContent(
-            message_key="toasts_thruster_test_title",
-            message_args={"thruster": payload},
-            description_key="toasts_seconds_remaining",
-            description_args={"seconds": 10},
-        ),
-        action=cancel_thruster_test_action(payload),
-    )
+    state.thrusters.test_start_time = None
+    state.thrusters.last_remaining = 0
 
 
 async def handle_cancel_thruster_test(
@@ -65,6 +67,7 @@ async def handle_cancel_thruster_test(
     """
     log_info(f"Cancelling thruster test: {payload}")
     state.thrusters.test_thruster = None
+    state.thrusters.test_start_time = None
     toast_content(
         identifier=THRUSTER_TEST_TOAST_ID,
         variant=ToastVariant.INFO,

--- a/src/rov_firmware/websocket/receive/actions.py
+++ b/src/rov_firmware/websocket/receive/actions.py
@@ -50,6 +50,7 @@ async def handle_start_thruster_test(
         return
 
     log_info(f"Queueing thruster test: {payload}")
+    state.thrusters.test_request_id += 1
     state.thrusters.test_thruster = payload
     state.thrusters.test_start_time = None
     state.thrusters.last_remaining = 0
@@ -66,6 +67,7 @@ async def handle_cancel_thruster_test(
         payload: The thruster test configuration.
     """
     log_info(f"Cancelling thruster test: {payload}")
+    state.thrusters.test_request_id += 1
     state.thrusters.test_thruster = None
     state.thrusters.test_start_time = None
     toast_content(

--- a/src/rov_firmware/websocket/send/status.py
+++ b/src/rov_firmware/websocket/send/status.py
@@ -64,6 +64,7 @@ def build_status_update(state: RovState) -> StatusUpdate:
         battery_percentage=int(state.system_status.battery_percentage),
         current_draw=current_draw,
         pi_undervoltage=is_pi_undervoltage_detected(),
+        thruster_control_ready=state.system_status.thruster_control_ready,
         health=state.system_health,
         device_info=state.device_info,
         esc_firmware_update=state.esc_firmware_update,

--- a/src/rov_firmware/websocket/send/telemetry.py
+++ b/src/rov_firmware/websocket/send/telemetry.py
@@ -47,7 +47,14 @@ def build_telemetry(state: RovState) -> Telemetry:
         water_temperature=state.pressure.temperature,
         electronics_temperature=electronics_temperature,
         thruster_rpms=thruster_rpms,
-        thruster_signal_qualities=list(state.mcu_telemetry.signal_quality),
+        thruster_signal_qualities=[
+            quality if valid else None
+            for quality, valid in zip(
+                state.mcu_telemetry.signal_quality,
+                state.mcu_telemetry.signal_quality_valid,
+                strict=True,
+            )
+        ],
         work_indicator_percentage=state.thrusters.work_indicator_percentage,
     )
     return Telemetry(payload=payload)

--- a/src/tools/mock_websocket_server.py
+++ b/src/tools/mock_websocket_server.py
@@ -211,6 +211,7 @@ async def _handle_client(websocket: ServerConnection) -> None:  # noqa: C901,PLR
                     "batteryPercentage": battery_percentage,
                     "currentDraw": current_draw,
                     "piUndervoltage": False,
+                    "thrusterControlReady": True,
                     "health": {
                         "mcuHealthy": True,
                         "imuHealthy": True,

--- a/tests/test_mcu_sensor.py
+++ b/tests/test_mcu_sensor.py
@@ -196,10 +196,20 @@ def test_invalid_release_warning_is_once_per_connection_generation(
 def test_clearing_serial_connection_clears_live_mcu_identity(rov_state):
     serial_manager = SerialManager(rov_state)
     rov_state.device_info.mcu_firmware_version = "1.2.3-rc.1"
+    rov_state.system_status.thruster_control_ready = True
 
     asyncio.run(serial_manager._clear_connection_unlocked())
 
     assert rov_state.device_info.mcu_firmware_version == ""
+    assert rov_state.system_status.thruster_control_ready is False
+
+
+def test_matching_runtime_config_ack_marks_thruster_control_ready(rov_state):
+    serial_manager = SerialManager(rov_state)
+
+    serial_manager.record_mcu_protocol_config("dshot", 300)
+
+    assert rov_state.system_status.thruster_control_ready is True
 
 
 def test_version_mismatch_auto_flashes_only_once_per_service_start(
@@ -252,6 +262,23 @@ def test_signal_quality_updates_do_not_keep_stale_current_alive(rov_state, monke
     assert rov_state.mcu_telemetry.current[0] == 0
     assert rov_state.mcu_telemetry.current_valid[0] is False
     assert rov_state.mcu_telemetry.signal_quality[0] == 100
+    assert rov_state.mcu_telemetry.signal_quality_valid[0] is True
+
+
+def test_stale_signal_quality_becomes_unavailable(rov_state, monkeypatch):
+    now = 10.0
+    monkeypatch.setattr(mcu_module.time, "monotonic", lambda: now)
+    sensor = McuSensor(rov_state, SerialManager(rov_state))
+    sensor._update_telemetry_item(0, MCU_TELEMETRY_TYPE_SIGNAL_QUALITY, 0)
+
+    assert rov_state.mcu_telemetry.signal_quality[0] == 0
+    assert rov_state.mcu_telemetry.signal_quality_valid[0] is True
+
+    now = 14.0
+    sensor._expire_stale_telemetry()
+
+    assert rov_state.mcu_telemetry.signal_quality[0] == 0
+    assert rov_state.mcu_telemetry.signal_quality_valid[0] is False
 
 
 def test_current_telemetry_preserves_raw_edt_amperes(rov_state):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -11,6 +11,14 @@ def test_status_reports_pi_undervoltage(rov_state, monkeypatch):
     assert message.model_dump(by_alias=True)["payload"]["piUndervoltage"] is True
 
 
+def test_status_reports_thruster_control_readiness(rov_state):
+    rov_state.system_status.thruster_control_ready = True
+
+    payload = status.build_status_update(rov_state).model_dump(by_alias=True)["payload"]
+
+    assert payload["thrusterControlReady"] is True
+
+
 def test_status_reports_read_only_device_versions(rov_state):
     rov_state.device_info.mcu_firmware_version = "1.2.3-rc.1"
     rov_state.device_info.esc_firmware_versions = ["2.20.0-rc.3"] * 8

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,13 @@
+from rov_firmware.websocket.send.telemetry import build_telemetry
+
+
+def test_signal_quality_distinguishes_zero_from_unavailable(rov_state):
+    rov_state.mcu_telemetry.signal_quality[0] = 0.0
+    rov_state.mcu_telemetry.signal_quality_valid[0] = True
+    rov_state.mcu_telemetry.signal_quality[1] = 75.5
+    rov_state.mcu_telemetry.signal_quality_valid[1] = False
+
+    payload = build_telemetry(rov_state).model_dump(by_alias=True)["payload"]
+
+    assert payload["thrusterSignalQualities"][0] == 0.0
+    assert payload["thrusterSignalQualities"][1] is None

--- a/tests/test_thrusters.py
+++ b/tests/test_thrusters.py
@@ -20,6 +20,7 @@ from rov_firmware.constants import (
 from rov_firmware.models.config import ThrusterPinSetup
 from rov_firmware.regulator import Regulator as RegulatorController
 from rov_firmware.thrusters import Thrusters
+from rov_firmware.websocket.receive.actions import handle_start_thruster_test
 
 
 class _WriterSpy:
@@ -371,11 +372,57 @@ def test_thruster_test_countdown_starts_after_first_command_write(
     assert thrusters.state.thrusters.test_start_time is None
     assert toasts == []
 
-    thrusters._mark_thruster_test_started(100.0)
+    thrusters._mark_thruster_test_started(
+        100.0, thrusters.state.thrusters.test_request_id
+    )
 
     assert thrusters.state.thrusters.test_start_time == 100.0
     assert thrusters.state.thrusters.last_remaining == 10
     assert toasts[0]["variant"].value == "loading"
+    assert toasts[0]["content"].description_args == {"seconds": 10}
+
+
+def test_unrelated_write_cannot_start_test_queued_while_drain_yields(
+    thrusters, monkeypatch
+):
+    toasts = []
+    monkeypatch.setattr(
+        thrusters_module, "toast_content", lambda **kwargs: toasts.append(kwargs)
+    )
+    thrusters.state.system_status.thruster_control_ready = True
+
+    async def run_interleaving() -> None:
+        vector, _, selected_request_id = thrusters._determine_thrust_vector(100.0, 0.0)
+        assert vector is not None
+        thrust_values = thrusters._compute_thrust_values(vector)
+
+        class _InterleavingWriter(_WriterSpy):
+            async def drain(self):
+                await asyncio.sleep(0)
+                await handle_start_thruster_test(thrusters.state, 3)
+                await super().drain()
+
+        sent = await thrusters._send_with_retries(
+            cast(Any, _InterleavingWriter()), thrust_values
+        )
+        assert sent is True
+        thrusters._mark_thruster_test_started(100.0, selected_request_id)
+
+        assert thrusters.state.thrusters.test_thruster == 3
+        assert thrusters.state.thrusters.test_start_time is None
+        assert toasts == []
+
+        test_vector, _, test_request_id = thrusters._determine_thrust_vector(101.0, 0.0)
+        assert test_vector is not None
+        sent = await thrusters._send_with_retries(
+            cast(Any, _WriterSpy()), thrusters._compute_thrust_values(test_vector)
+        )
+        assert sent is True
+        thrusters._mark_thruster_test_started(101.0, test_request_id)
+
+    asyncio.run(run_interleaving())
+
+    assert thrusters.state.thrusters.test_start_time == 101.0
     assert toasts[0]["content"].description_args == {"seconds": 10}
 
 

--- a/tests/test_thrusters.py
+++ b/tests/test_thrusters.py
@@ -351,5 +351,45 @@ def test_protocol_config_logs_actionable_error_when_ack_stays_blocked(
 
     assert messages == [
         "Thruster protocol change is still blocked because the MCU has not "
-        "confirmed it. Check power and telemetry for every ESC."
+        "confirmed it. Check the MCU connection and firmware."
     ]
+
+
+def test_thruster_test_countdown_starts_after_first_command_write(
+    thrusters, monkeypatch
+):
+    toasts = []
+    monkeypatch.setattr(
+        thrusters_module, "toast_content", lambda **kwargs: toasts.append(kwargs)
+    )
+    thrusters.state.thrusters.test_thruster = 3
+
+    vector = thrusters._handle_thruster_test(100.0, 3)
+
+    assert vector is not None
+    assert vector[3] == pytest.approx(0.1)
+    assert thrusters.state.thrusters.test_start_time is None
+    assert toasts == []
+
+    thrusters._mark_thruster_test_started(100.0)
+
+    assert thrusters.state.thrusters.test_start_time == 100.0
+    assert thrusters.state.thrusters.last_remaining == 10
+    assert toasts[0]["variant"].value == "loading"
+    assert toasts[0]["content"].description_args == {"seconds": 10}
+
+
+def test_lost_readiness_ends_thruster_test_with_terminal_error(thrusters, monkeypatch):
+    toasts = []
+    monkeypatch.setattr(
+        thrusters_module, "toast_content", lambda **kwargs: toasts.append(kwargs)
+    )
+    thrusters.state.thrusters.test_thruster = 2
+    thrusters.state.thrusters.test_start_time = 50.0
+
+    thrusters._fail_thruster_test_unavailable()
+
+    assert thrusters.state.thrusters.test_thruster is None
+    assert thrusters.state.thrusters.test_start_time is None
+    assert toasts[0]["variant"].value == "error"
+    assert toasts[0]["content"].message_key == "toasts_thruster_test_unavailable"

--- a/tests/test_websocket_actions.py
+++ b/tests/test_websocket_actions.py
@@ -1,0 +1,30 @@
+import asyncio
+
+from rov_firmware.websocket.receive import actions
+
+
+def test_thruster_test_is_rejected_until_control_is_ready(rov_state, monkeypatch):
+    toasts = []
+    monkeypatch.setattr(
+        actions, "toast_content", lambda **kwargs: toasts.append(kwargs)
+    )
+
+    asyncio.run(actions.handle_start_thruster_test(rov_state, 4))
+
+    assert rov_state.thrusters.test_thruster is None
+    assert toasts[0]["variant"].value == "error"
+    assert toasts[0]["content"].message_key == "toasts_thruster_test_unavailable"
+
+
+def test_thruster_test_is_queued_without_starting_countdown(rov_state, monkeypatch):
+    toasts = []
+    monkeypatch.setattr(
+        actions, "toast_content", lambda **kwargs: toasts.append(kwargs)
+    )
+    rov_state.system_status.thruster_control_ready = True
+
+    asyncio.run(actions.handle_start_thruster_test(rov_state, 4))
+
+    assert rov_state.thrusters.test_thruster == 4
+    assert rov_state.thrusters.test_start_time is None
+    assert toasts == []


### PR DESCRIPTION
The calibration test toast starts before the Pi can send a motor command. If MCU configuration acknowledgement is delayed, the toast stays at 10 seconds and the selected motor never spins.

This change exposes `thrusterControlReady`, rejects or terminates tests when output is unavailable, and starts the countdown only after the first non-neutral packet is written. Signal quality now carries `null` when no recent MCU quality report exists, while a measured `0` remains `0%`. The mock WebSocket server includes the new readiness field.

This intentionally updates the current WebSocket contract without compatibility handling for older release candidates.

Depends on manafishrov/mcu-firmware#10. The current Nix image still bundles MCU v1.0.3-rc.3. After the MCU change is released, a separate pin update is required before building the next Pi release candidate.

## Verification

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest`: 219 tests passed

Hardware-in-the-loop testing was not available. The remaining persistent `0%` report needs the planned hardware log capture; this PR adds the per-motor Pico diagnostics needed to identify timeout, GCR, CRC, or telemetry-type failures.

---
Generated by UNKNOWN-MODEL using the Codex harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added thruster-control readiness status to system and status updates.
  * Thruster tests now require confirmed readiness before starting.
  * Test countdowns begin after the first successful motor command.
  * Invalid or stale signal-quality readings are reported as unavailable.

* **Bug Fixes**
  * Thruster tests stop safely when connection, synchronization, or motor output is lost.
  * Improved test timing, request tracking, and state reset behavior.
  * Updated default values for thruster test status fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->