### PR TITLE
chore(release): v1.1.6-rc.7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,25 +104,25 @@
     "mcu-firmware-pico": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-SG0mPPGYTBVBkLECNpLb599L1x6WwYoIyy8QE9GCcC4=",
+        "narHash": "sha256-ihtWSFczSBiQXBPpITHqsKSFgrkOZha2msaCFxVpvQI=",
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico-v1.0.3-rc.3.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.4/pico-v1.0.3-rc.4.uf2"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico-v1.0.3-rc.3.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.4/pico-v1.0.3-rc.4.uf2"
       }
     },
     "mcu-firmware-pico2": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-GE35xOV/MBjoCcp////0/ttGGex1JoslFXRagoaXRpw=",
+        "narHash": "sha256-dU4TfjnA5LR081vCyJyuBqZhA91+syPKMTS06SaaAf4=",
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico2-v1.0.3-rc.3.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.4/pico2-v1.0.3-rc.4.uf2"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico2-v1.0.3-rc.3.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.4/pico2-v1.0.3-rc.4.uf2"
       }
     },
     "ms5837-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,11 +40,11 @@
       flake = false;
     };
     mcu-firmware-pico = {
-      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico-v1.0.3-rc.3.uf2";
+      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.4/pico-v1.0.3-rc.4.uf2";
       flake = false;
     };
     mcu-firmware-pico2 = {
-      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.3/pico2-v1.0.3-rc.3.uf2";
+      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.4/pico2-v1.0.3-rc.4.uf2";
       flake = false;
     };
     esc-firmware = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.1.6-rc.6"
+version = "1.1.6-rc.7"
 description = "Firmware for the Manafish ROV"
 license = "AGPL-3.0-or-later"
 requires-python = "==3.13.14"

--- a/uv.lock
+++ b/uv.lock
@@ -109,7 +109,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/56/33/26ec2e8049eaa2f07
 
 [[package]]
 name = "manafish"
-version = "1.1.6rc6"
+version = "1.1.6rc7"
 source = { editable = "." }
 dependencies = [
     { name = "bmi270" },


### PR DESCRIPTION
Prepare the Pi firmware release candidate for ROV testing.

This updates the firmware identity to `1.1.6-rc.7` and bundles the published Pico and Pico 2 firmware `v1.0.3-rc.4`.

Verification:
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` (244 passed)
- `nix flake check --show-trace`
- `nix build --accept-flake-config --dry-run`

ROV hardware testing is still required for this release candidate.

---
Generated by UNKNOWN-MODEL using the Codex harness.