### PR TITLE
fix(firmware): roll out binary-safe Pico and retain field diagnostics

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,25 +104,25 @@
     "mcu-firmware-pico": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-+AbpzEL890yh5LD9sVTm9UrqHH43yK0in9vhwoSHIFU=",
+        "narHash": "sha256-d/JCL0IMIfk5RhAhmzBo7xR2B0feW1thU0hrRdMqF5A=",
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.5/pico-v1.0.3-rc.5.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico-v1.0.3-rc.6.uf2"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.5/pico-v1.0.3-rc.5.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico-v1.0.3-rc.6.uf2"
       }
     },
     "mcu-firmware-pico2": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-zvJjviZ9KXnzI/XR0cXkd2/VeQEeGpQaBkEnBVptE4E=",
+        "narHash": "sha256-v48bAjdETqgCBsXZXIH3bCZazhCkC5FiaYkbAL5Ze5U=",
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.5/pico2-v1.0.3-rc.5.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico2-v1.0.3-rc.6.uf2"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.5/pico2-v1.0.3-rc.5.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico2-v1.0.3-rc.6.uf2"
       }
     },
     "ms5837-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,11 +40,11 @@
       flake = false;
     };
     mcu-firmware-pico = {
-      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.5/pico-v1.0.3-rc.5.uf2";
+      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico-v1.0.3-rc.6.uf2";
       flake = false;
     };
     mcu-firmware-pico2 = {
-      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.5/pico2-v1.0.3-rc.5.uf2";
+      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico2-v1.0.3-rc.6.uf2";
       flake = false;
     };
     esc-firmware = {

--- a/nix/impermanence.nix
+++ b/nix/impermanence.nix
@@ -31,6 +31,7 @@ in {
       device = "/persistent/boot";
       fsType = "none";
       options = ["bind"];
+      depends = ["/persistent"];
       neededForBoot = true;
     };
     "/nix" = {

--- a/nix/impermanence.nix
+++ b/nix/impermanence.nix
@@ -12,6 +12,8 @@
   resize2fs = lib.getExe' pkgs.e2fsprogs "resize2fs";
 in {
   sdImage.expandOnBoot = false;
+  # The SD root is mounted here; / itself is tmpfs and hides this file.
+  sdImage.nixPathRegistrationFile = "/persistent/nix-path-registration";
 
   fileSystems = {
     "/" = lib.mkForce {
@@ -22,6 +24,13 @@ in {
     "/persistent" = {
       device = "/dev/disk/by-label/NIXOS_SD";
       fsType = "ext4";
+      neededForBoot = true;
+    };
+    # U-Boot reads extlinux entries from the SD partition, not the tmpfs root.
+    "/boot" = {
+      device = "/persistent/boot";
+      fsType = "none";
+      options = ["bind"];
       neededForBoot = true;
     };
     "/nix" = {

--- a/src/rov_firmware/diagnostics.py
+++ b/src/rov_firmware/diagnostics.py
@@ -1,0 +1,352 @@
+"""Bounded field diagnostics carried by the existing debug log stream.
+
+Sampling and serialization run separately from motor writes. These observations
+never change control, current limits, or update/recovery policy.
+"""
+
+import asyncio
+from collections import deque
+import hashlib
+import json
+from pathlib import Path
+import time
+from typing import TYPE_CHECKING, cast
+
+from .constants import THRUSTER_TIMEOUT_MS
+from .log import log_info, log_warn
+from .models.config import CURRENT_FIRMWARE_VERSION
+from .sensors.pi_power import read_pi_undervoltage
+from .websocket.state import websocket_state
+
+
+if TYPE_CHECKING:
+    from .rov_state import RovState
+    from .sensors.mcu import McuSensor
+    from .serial import SerialManager
+    from .thrusters import Thrusters
+
+
+_SAMPLE_SECONDS = 1.0
+_SUMMARY_SECONDS = 10.0
+_HISTORY_SAMPLES = 60
+_HISTORY_COOLDOWN_SECONDS = 30.0
+_CONFIG_FIELDS = {
+    "mcu_board",
+    "thruster_protocol",
+    "dshot_speed",
+    "current_sensing_mode",
+    "thruster_pin_setup",
+    "thruster_allocation",
+    "nullspace_vectors",
+    "regulator",
+    "direction_coefficients",
+    "power",
+    "smoothing_factor",
+    "camera",
+}
+
+
+def log_diagnostic(event: str, **fields: object) -> None:
+    """Emit allowlisted call-site fields, not arbitrary application configuration."""
+    log_info(
+        "diagnostic " + json.dumps({"event": event, **fields}, separators=(",", ":"))
+    )
+
+
+def firmware_manifest(home: Path) -> list[dict[str, object]]:
+    """Hash staged images off the control loop; never inspect keys or credentials."""
+    images: list[dict[str, object]] = []
+    for directory, pattern in (("mcu-firmware", "*.uf2"), ("esc-firmware", "esc-v*.*")):
+        for path in sorted((home / directory).glob(pattern)):
+            if path.suffix not in {".uf2", ".bin", ".hex"}:
+                continue
+            try:
+                with path.open("rb") as image:
+                    digest = hashlib.file_digest(image, "sha256").hexdigest()
+                images.append(
+                    {"file": path.name, "sha256": digest, "bytes": path.stat().st_size}
+                )
+            except OSError:
+                images.append({"file": path.name, "error": "unreadable"})
+    return images
+
+
+class FieldDiagnostics:
+    """One sample/second, one normal log/ten seconds, bounded fault history."""
+
+    def __init__(
+        self,
+        state: "RovState",
+        serial: "SerialManager",
+        mcu: "McuSensor",
+        thrusters: "Thrusters",
+    ) -> None:
+        """Observe the existing state owners without adding control dependencies."""
+        self.state = state
+        self.serial = serial
+        self.mcu = mcu
+        self.thrusters = thrusters
+        self._history: deque[dict[str, object]] = deque(maxlen=_HISTORY_SAMPLES)
+        self._last_summary = float("-inf")
+        self._last_history = float("-inf")
+        self._last_state: str | None = None
+        self._last_config: str | None = None
+        self._last_faults: frozenset[str] = frozenset()
+        self._connected = False
+        self._client_generation = -1
+        self._manifest: list[dict[str, object]] = []
+        self._system_path: str | None = None
+        self._last_invalid_usb_packets = 0
+        self._input_was_fresh = False
+        self._pending_faults: dict[str, float] = {}
+        self._events: list[tuple[str, dict[str, object]]] | None = None
+
+    def _emit(self, event: str, **fields: object) -> None:
+        if self._events is None:
+            log_diagnostic(event, **fields)
+        else:
+            self._events.append((event, fields))
+
+    def sample(
+        self,
+        now: float,
+        *,
+        undervoltage: bool | None,
+        scheduler_lag: float = 0.0,
+        power_probe_s: float = 0.0,
+    ) -> None:
+        """Capture only observed values; an old/missing sample is never a zero."""
+        state = self.state
+        connected = websocket_state.is_client_connected
+        new_connection = connected and (
+            not self._connected
+            or self._client_generation != websocket_state.connection_generation
+        )
+        self._connected = connected
+        self._client_generation = websocket_state.connection_generation
+        config = state.rov_config.model_dump(mode="json", include=_CONFIG_FIELDS)
+        config_key = json.dumps(config, sort_keys=True)
+        if config_key != self._last_config or new_connection:
+            self._emit(
+                "configuration",
+                firmware=CURRENT_FIRMWARE_VERSION,
+                images=self._manifest,
+                system_path=self._system_path,
+                utc_clock_verified=False,
+                telemetry_units={
+                    "erpm": "electrical RPM",
+                    "voltage": "V",
+                    "temperature": "C",
+                    "current": "signed wire A",
+                    "signal_quality": "%",
+                },
+                command_units="USB throttle counts 0..2000 (1000 neutral), physical channels 1-8; not electrical pulse widths or ESC acknowledgements",
+                config=config,
+            )
+            self._last_config = config_key
+        status = {
+            "usb_generation": self.serial.connection_generation,
+            "usb_connected": state.system_health.mcu_healthy,
+            "protocol_state": state.system_status.thruster_protocol_state,
+            "protocol_error": state.system_status.thruster_protocol_error,
+            "ready": state.system_status.thruster_control_ready,
+            "identity": state.device_info.model_dump(mode="json"),
+            "health": state.system_health.model_dump(mode="json"),
+            "pico_flashing": state.mcu_flashing,
+            "esc_update": state.esc_firmware_update.model_dump(mode="json"),
+            "pi_undervoltage": undervoltage,
+        }
+        # Progress itself is logged by the updater, not once per percentage here.
+        state_key = json.dumps(
+            {key: value for key, value in status.items() if key != "esc_update"},
+            sort_keys=True,
+        )
+        if state_key != self._last_state or new_connection:
+            self._emit("state", **status)
+            self._last_state = state_key
+        telemetry = self.mcu.diagnostic_snapshot(now)
+        last_input = state.thrusters.last_direction_time
+        input_age = max(0.0, time.time() - last_input) if last_input > 0 else None
+        watchdog_neutral = (
+            (input_age is None or input_age >= THRUSTER_TIMEOUT_MS / 1000)
+            and state.thrusters.test_thruster is None
+            and not state.regulator.auto_tuning_active
+        )
+        vector = state.thrusters.direction_vector
+        snapshot: dict[str, object] = {
+            "mono_s": round(now, 3),
+            "usb_generation": self.serial.connection_generation,
+            "ready": state.system_status.thruster_control_ready,
+            "input_age_s": None if input_age is None else round(input_age, 3),
+            "input_expired": watchdog_neutral,
+            "requested_direction": None if vector is None else vector.tolist(),
+            "control": self.thrusters.diagnostic_snapshot(now),
+            "regulator": state.regulator.model_dump(
+                mode="json",
+                include={
+                    "pitch",
+                    "roll",
+                    "yaw",
+                    "desired_pitch",
+                    "desired_roll",
+                    "desired_yaw",
+                    "desired_depth",
+                },
+            ),
+            "auto_stabilization": state.system_status.auto_stabilization,
+            "depth_hold": state.system_status.depth_hold,
+            "depth_m": state.pressure.depth
+            if state.system_health.pressure_sensor_healthy
+            else None,
+            "pi_undervoltage": undervoltage,
+            "sampler_lag_s": round(scheduler_lag, 4),
+            "power_probe_s": round(power_probe_s, 4),
+            "invalid_usb_packets": self.mcu.invalid_usb_packets,
+            "esc": telemetry,
+        }
+        self._history.append(snapshot)
+        faults = self._faults(telemetry, undervoltage)
+        new_faults = faults - self._last_faults
+        if self._input_was_fresh and watchdog_neutral:
+            self._emit("input_watchdog_expired", input_age_s=input_age)
+            new_faults = new_faults | {"input_watchdog_expired"}
+        self._input_was_fresh = not watchdog_neutral
+        if self.mcu.invalid_usb_packets > self._last_invalid_usb_packets:
+            new_faults = new_faults | {"invalid_usb_packet"}
+        self._last_invalid_usb_packets = self.mcu.invalid_usb_packets
+        for reason in new_faults:
+            self._pending_faults.setdefault(reason, now)
+        if (
+            self._pending_faults
+            and now - self._last_history >= _HISTORY_COOLDOWN_SECONDS
+        ):
+            self._emit(
+                "fault_history",
+                reasons=dict(self._pending_faults),
+                sample_interval_s=_SAMPLE_SECONDS,
+                sample_count=len(self._history),
+                history_id=round(now, 3),
+            )
+            # Separate records avoid journal line truncation and huge viewer rows.
+            for sample in self._history:
+                self._emit("history_sample", history_id=round(now, 3), **sample)
+            self._pending_faults.clear()
+            self._last_history = now
+        if now - self._last_summary >= _SUMMARY_SECONDS or new_connection:
+            self._emit("snapshot", **self._summary(snapshot))
+            self._last_summary = now
+        self._last_faults = faults
+
+    def _summary(self, snapshot: dict[str, object]) -> dict[str, object]:
+        # Extrema span every one-second sample, not just the tenth second.
+        window = [
+            sample
+            for sample in self._history
+            if cast(float, sample["mono_s"]) > round(self._last_summary, 3)
+        ]
+        telemetry = [cast(list[dict[str, object]], sample["esc"]) for sample in window]
+        channels = [
+            dict(channel) for channel in cast(list[dict[str, object]], snapshot["esc"])
+        ]
+        for index, channel in enumerate(channels):
+            lows = [row[index]["erpm_min_since_sample"] for row in telemetry]
+            highs = [row[index]["erpm_max_since_sample"] for row in telemetry]
+            channel["erpm_window_min"] = min(
+                (value for value in lows if isinstance(value, (int, float))),
+                default=None,
+            )
+            channel["erpm_window_max"] = max(
+                (value for value in highs if isinstance(value, (int, float))),
+                default=None,
+            )
+        controls = [cast(dict[str, object], sample["control"]) for sample in window]
+        control = dict(cast(dict[str, object], snapshot["control"]))
+        control["max_write_gap_s"] = max(
+            (cast(float, row["max_write_gap_s"]) for row in controls), default=0.0
+        )
+        control["write_gaps_over_two_periods"] = sum(
+            cast(int, row["write_gaps_over_two_periods"]) for row in controls
+        )
+        for suffix, operation in (("min", min), ("max", max)):
+            values = [
+                cast(list[int], row[f"usb_command_{suffix}_since_sample"])
+                for row in controls
+                if row[f"usb_command_{suffix}_since_sample"] is not None
+            ]
+            control[f"usb_command_window_{suffix}"] = (
+                [operation(channel) for channel in zip(*values, strict=True)]
+                if values
+                else None
+            )
+        return {
+            **snapshot,
+            "esc": channels,
+            "control": control,
+            "window_start_mono_s": window[0]["mono_s"]
+            if window
+            else snapshot["mono_s"],
+            "window_sample_count": len(window),
+        }
+
+    def _faults(
+        self, telemetry: list[dict[str, object]], undervoltage: bool | None
+    ) -> frozenset[str]:
+        faults: set[str] = set()
+        if undervoltage:
+            faults.add("pi_undervoltage")
+        if self.state.system_status.thruster_protocol_state == "failed":
+            faults.add("protocol_failed")
+        if self._last_state is not None and not self.state.system_health.mcu_healthy:
+            faults.add("usb_disconnected")
+        if self.state.esc_firmware_update.error:
+            faults.add("esc_update_failed")
+        for channel in telemetry:
+            if channel["erpm_stale"]:
+                faults.add(f"erpm_stale_{channel['channel']}")
+        return frozenset(faults)
+
+    async def run(self) -> None:
+        """Diagnostics failures must not stop the ROV or cause a log storm."""
+        try:
+            self._manifest = await asyncio.to_thread(firmware_manifest, Path.home())
+            try:
+                self._system_path = str(Path("/run/current-system").readlink())
+            except OSError:
+                self._system_path = None
+        except Exception as error:
+            log_warn(f"Diagnostic firmware inventory failed: {type(error).__name__}")
+        next_sample = time.monotonic()
+        last_error = float("-inf")
+        while True:
+            await asyncio.sleep(max(0.0, next_sample - time.monotonic()))
+            probe_start = time.monotonic()
+            events: list[tuple[str, dict[str, object]]] = []
+            self._events = events
+            try:
+                undervoltage = await asyncio.to_thread(read_pi_undervoltage)
+                captured_at = time.monotonic()
+                self.sample(
+                    captured_at,
+                    undervoltage=undervoltage,
+                    scheduler_lag=max(0.0, captured_at - next_sample),
+                    power_probe_s=captured_at - probe_start,
+                )
+                # Serialize bounded records one at a time, yielding to motor IO.
+                for event, fields in events:
+                    log_diagnostic(event, **fields)
+                    await asyncio.sleep(0)
+            except Exception as error:
+                now = time.monotonic()
+                if now - last_error >= _HISTORY_COOLDOWN_SECONDS:
+                    log_warn(
+                        f"Field diagnostics failed: {type(error).__name__}: {error}"
+                    )
+                    last_error = now
+            finally:
+                self._events = None
+            next_sample += _SAMPLE_SECONDS
+            now = time.monotonic()
+            if next_sample < now:
+                next_sample += (
+                    int((now - next_sample) / _SAMPLE_SECONDS) + 1
+                ) * _SAMPLE_SECONDS

--- a/src/rov_firmware/esc_firmware.py
+++ b/src/rov_firmware/esc_firmware.py
@@ -24,6 +24,7 @@ from .constants import (
     ESC_FIRMWARE_USB_STATUS_START_BYTE,
     NUM_MOTORS,
 )
+from .diagnostics import log_diagnostic
 from .esc_recovery import clear_recovery_required, mark_recovery_required
 from .log import log_error, log_info, log_warn
 from .models.config import ThrusterProtocol
@@ -468,8 +469,21 @@ def _data_packet(
 
 
 async def _write_packet(writer: asyncio.StreamWriter, packet: bytes) -> None:
+    control = packet[0] == ESC_FIRMWARE_USB_CONTROL_START_BYTE
+    if control:
+        log_diagnostic(
+            "esc_control_attempt",
+            command=_Command(packet[1]).name,
+            transaction=packet[2],
+        )
     writer.write(packet)
     await writer.drain()
+    if control:
+        log_diagnostic(
+            "esc_control_written",
+            command=_Command(packet[1]).name,
+            transaction=packet[2],
+        )
 
 
 async def _read_status(
@@ -479,6 +493,8 @@ async def _read_status(
     timeout: float = _STATUS_TIMEOUT_S,
 ) -> tuple[_Status, int, int, int, int, int]:
     deadline = time.monotonic() + timeout
+    invalid_packets = 0
+    last_invalid_hex: str | None = None
     while True:
         start = read_buffer.find(bytes((ESC_FIRMWARE_USB_STATUS_START_BYTE,)))
         if (
@@ -487,11 +503,15 @@ async def _read_status(
         ):
             packet = read_buffer[start : start + ESC_FIRMWARE_USB_STATUS_PACKET_SIZE]
             if _checksum(packet[:-1]) != packet[-1]:
+                invalid_packets += 1
+                last_invalid_hex = packet[:32].hex()
                 del read_buffer[: start + 1]
                 continue
             try:
                 status = _Status(packet[1])
             except ValueError:
+                invalid_packets += 1
+                last_invalid_hex = packet[:32].hex()
                 del read_buffer[: start + 1]
                 continue
             del read_buffer[: start + ESC_FIRMWARE_USB_STATUS_PACKET_SIZE]
@@ -505,11 +525,25 @@ async def _read_status(
 
         remaining = deadline - time.monotonic()
         if remaining <= 0:
+            log_diagnostic(
+                "esc_status_timeout",
+                invalid_packets=invalid_packets,
+                last_invalid_hex=last_invalid_hex,
+                buffered_bytes=len(read_buffer),
+                buffer_tail_hex=read_buffer[-32:].hex(),
+            )
             msg = "Timed out waiting for the Pico ESC firmware updater"
             raise _PicoStatusTimeoutError(msg)
         try:
             data = await asyncio.wait_for(reader.read(128), timeout=remaining)
         except TimeoutError as error:
+            log_diagnostic(
+                "esc_status_timeout",
+                invalid_packets=invalid_packets,
+                last_invalid_hex=last_invalid_hex,
+                buffered_bytes=len(read_buffer),
+                buffer_tail_hex=read_buffer[-32:].hex(),
+            )
             msg = "Timed out waiting for the Pico ESC firmware updater"
             raise _PicoStatusTimeoutError(msg) from error
         if not data:
@@ -596,6 +630,14 @@ async def _write_with_ack_retry(
             )
             return
         except _PicoStatusTimeoutError:
+            log_diagnostic(
+                "esc_upload_retry",
+                transaction=transaction_id,
+                sequence=expected_sequence,
+                last_acknowledged_bytes=uploaded_bytes,
+                expected_bytes=expected_value,
+                attempt=attempt,
+            )
             await _write_packet(
                 writer, _control_packet(_Command.QUERY_OFFSET, transaction_id)
             )
@@ -606,6 +648,12 @@ async def _write_with_ack_retry(
                     _Status.RECEIVED,
                     expected_transaction=transaction_id,
                     timeout=_UPLOAD_ACK_TIMEOUT_S,
+                )
+                log_diagnostic(
+                    "esc_query_offset",
+                    transaction=transaction_id,
+                    received_bytes=current_offset,
+                    expected_bytes=expected_value,
                 )
                 if current_offset == expected_value:
                     return
@@ -637,6 +685,14 @@ async def _upload_image(  # noqa: PLR0913 - transport and update policy are sepa
     recovery: bool = False,
 ) -> None:
     transport = (reader, writer, read_buffer)
+    log_diagnostic(
+        "esc_upload_begin",
+        transaction=transaction_id,
+        image_bytes=len(image),
+        image_crc32=f"{zlib.crc32(image):08x}",
+        recovery=recovery,
+        commit_sent=False,
+    )
     await _write_with_ack_retry(
         transport,
         _control_packet(
@@ -659,6 +715,14 @@ async def _upload_image(  # noqa: PLR0913 - transport and update policy are sepa
             (_Status.RECEIVED, received, transaction_id, sequence),
             uploaded_bytes=offset,
         )
+        if sequence in (1, 10) or sequence % 64 == 0 or received == len(image):
+            log_diagnostic(
+                "esc_upload_ack",
+                transaction=transaction_id,
+                sequence=sequence,
+                acknowledged_bytes=received,
+                commit_sent=False,
+            )
         if progress is not None:
             progress(max(1, received * 10 // len(image)), None)
 
@@ -686,12 +750,28 @@ async def _flash_all_escs(
             return
 
 
+def _log_flash_status(status_packet: tuple[_Status, int, int, int, int, int]) -> None:
+    status, motor, error, value, transaction, sequence = status_packet
+    if status != _Status.MOTOR_BEGIN or value % 4096 == 0:
+        log_diagnostic(
+            "esc_programming_status",
+            transaction=transaction,
+            sequence=sequence,
+            status=status.name,
+            esc=motor + 1 if motor < NUM_MOTORS else None,
+            error=error,
+            value=value,
+            commit_sent=True,
+        )
+
+
 def _handle_flash_status(
     status_packet: tuple[_Status, int, int, int, int, int],
     image_size: int,
     progress: Callable[[int, int | None], None] | None,
 ) -> bool:
     status, motor, error, value, _, _ = status_packet
+    _log_flash_status(status_packet)
     if status == _Status.FAILED:
         raise _PostCommitFailureError(
             _format_updater_failure(motor, error),

--- a/src/rov_firmware/log.py
+++ b/src/rov_firmware/log.py
@@ -1,10 +1,17 @@
 """Logging utilities for the ROV firmware."""
 
 import asyncio
+from collections import deque
 from collections.abc import Callable, Coroutine
 import concurrent.futures
+from datetime import UTC, datetime
 import logging
+from pathlib import Path
+import threading
+import time
+import uuid
 
+from .log_buffer import BoundedJournalHandler
 from .models.log import LogEntry, LogLevel, LogOrigin
 from .websocket.message import LogMessage
 from .websocket.queue import get_message_queue
@@ -13,15 +20,46 @@ from .websocket.state import websocket_state
 
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)
+_logger.propagate = False
 
 if not _logger.handlers:
     _handler = logging.StreamHandler()
     _handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
-    _logger.addHandler(_handler)
+    _logger.addHandler(BoundedJournalHandler(_handler))
 
 
 _MAX_PENDING_LOGS = 100
-_pending_logs: list[LogMessage] = []
+_MAX_LOG_QUEUE_DEPTH = 200
+_flush_scheduled = False
+_pending_logs: deque[LogMessage] = deque(maxlen=_MAX_PENDING_LOGS)
+_pending_lock = threading.Lock()
+_dropped_logs = 0
+_SESSION_ID = uuid.uuid4().hex
+try:
+    _BOOT_ID = Path("/proc/sys/kernel/random/boot_id").read_text().strip()
+except OSError:
+    _BOOT_ID = "unavailable"
+
+
+def get_local_logger() -> logging.Logger:
+    """Return the bounded journal logger for failures that must not recurse."""
+    return _logger
+
+
+def stamp_log_message(message: str) -> str:
+    """Keep Pi generation time even when the app receives a buffered log later."""
+    return (
+        f"[pi session={_SESSION_ID} boot={_BOOT_ID} "
+        f"mono_s={time.monotonic():.3f} utc={datetime.now(UTC).isoformat()}] {message}"
+    )
+
+
+def _buffer_log(message: LogMessage) -> None:
+    global _dropped_logs  # noqa: PLW0603 - guarded by _pending_lock
+    with _pending_lock:
+        if len(_pending_logs) == _MAX_PENDING_LOGS:
+            _dropped_logs += 1
+        _pending_logs.append(message)
 
 
 def _log_future_failure(future: concurrent.futures.Future[None], label: str) -> None:
@@ -61,36 +99,72 @@ def submit_to_main_loop(
 
 
 async def flush_pending_logs() -> None:
-    """Flush pre-connection logs to the websocket message queue."""
+    """Flush only available log capacity; never limit control/config messages."""
+    global _dropped_logs  # noqa: PLW0603 - guarded by _pending_lock
     queue = get_message_queue()
-    for msg in _pending_logs:
-        await queue.put(msg)
-    _pending_logs.clear()
+    while queue.qsize() < _MAX_LOG_QUEUE_DEPTH:
+        with _pending_lock:
+            if _dropped_logs:
+                message = LogMessage(
+                    payload=LogEntry(
+                        origin=LogOrigin.FIRMWARE,
+                        level=LogLevel.WARN,
+                        message=stamp_log_message(
+                            f"Debug log buffer discarded {_dropped_logs} older records; "
+                            f"replaying the latest {len(_pending_logs)}. The local journal may contain earlier records."
+                        ),
+                    )
+                )
+                _dropped_logs = 0
+            elif _pending_logs:
+                message = _pending_logs.popleft()
+            else:
+                return
+        queue.put_nowait(message)
 
 
-async def _log_message_async(
-    level: LogLevel, message: str, origin: LogOrigin = LogOrigin.FIRMWARE
-) -> None:
-    payload = LogEntry(origin=origin, level=LogLevel(level), message=message)
-    message_model = LogMessage(payload=payload)
+async def _flush_when_connected() -> None:
+    global _flush_scheduled  # noqa: PLW0603 - guarded by _pending_lock
+    completed = False
+    try:
+        while websocket_state.is_client_connected:
+            await flush_pending_logs()
+            with _pending_lock:
+                if not _pending_logs:
+                    break
+            await asyncio.sleep(0.25)
+        completed = True
+    finally:
+        with _pending_lock:
+            _flush_scheduled = False
+        # A worker thread may append between the empty check and flag reset.
+        if completed:
+            _schedule_flush()
 
-    if websocket_state.is_client_connected:
-        await get_message_queue().put(message_model)
-    else:
-        if len(_pending_logs) < _MAX_PENDING_LOGS:
-            _pending_logs.append(message_model)
-        _logger.log(_map_log_level(level), message)
+
+def _schedule_flush() -> None:
+    global _flush_scheduled  # noqa: PLW0603 - guarded by _pending_lock
+    if not websocket_state.is_client_connected:
+        return
+    with _pending_lock:
+        if _flush_scheduled or not _pending_logs:
+            return
+        _flush_scheduled = True
+    if not submit_to_main_loop(_flush_when_connected, "flush_debug_logs"):
+        with _pending_lock:
+            _flush_scheduled = False
 
 
 def _log_message(
     level: LogLevel, message: str, origin: LogOrigin = LogOrigin.FIRMWARE
 ) -> None:
-    scheduled = submit_to_main_loop(
-        lambda: _log_message_async(level, message, origin),
-        f"log_message[{level}]",
+    message = stamp_log_message(message)
+    # Always retain a local copy, including while an app is connected.
+    _logger.log(_map_log_level(level), "[%s] %s", origin.value, message)
+    _buffer_log(
+        LogMessage(payload=LogEntry(origin=origin, level=level, message=message))
     )
-    if not scheduled:
-        _logger.log(_map_log_level(level), message)
+    _schedule_flush()
 
 
 def _map_log_level(level: LogLevel) -> int:

--- a/src/rov_firmware/log_buffer.py
+++ b/src/rov_firmware/log_buffer.py
@@ -1,0 +1,66 @@
+"""Nonblocking, bounded local journal output for the control event loop."""
+
+import logging
+import queue
+import threading
+
+
+class BoundedJournalHandler(logging.Handler):
+    """Drop oldest records under backpressure rather than block motor control."""
+
+    def __init__(self, sink: logging.Handler, capacity: int = 256) -> None:
+        """Start one daemon writer; no file or stream writes occur in emit()."""
+        super().__init__()
+        self._sink = sink
+        self._records: queue.Queue[logging.LogRecord] = queue.Queue(maxsize=capacity)
+        self._drop_lock = threading.Lock()
+        self._dropped = 0
+        self.dropped_total = 0
+        threading.Thread(target=self._drain, name="journal-writer", daemon=True).start()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Enqueue without waiting for journal IO."""
+        try:
+            self._records.put_nowait(record)
+        except queue.Full:
+            try:
+                self._records.get_nowait()
+            except queue.Empty:
+                pass
+            else:
+                with self._drop_lock:
+                    self._dropped += 1
+                    self.dropped_total += 1
+            try:
+                self._records.put_nowait(record)
+            except queue.Full:
+                # Handler.handle serializes producers; this also tolerates direct emit.
+                with self._drop_lock:
+                    self._dropped += 1
+                    self.dropped_total += 1
+
+    def _drain(self) -> None:
+        while True:
+            record = self._records.get()
+            with self._drop_lock:
+                dropped = self._dropped
+                self._dropped = 0
+            try:
+                if dropped:
+                    self._sink.handle(
+                        logging.LogRecord(
+                            "journal-buffer",
+                            logging.WARNING,
+                            "",
+                            0,
+                            "Local journal queue discarded %s older records under backpressure",
+                            (dropped,),
+                            None,
+                        )
+                    )
+                self._sink.handle(record)
+            except Exception:
+                # A failed journal sink must never terminate the control service.
+                with self._drop_lock:
+                    self._dropped += 1
+                    self.dropped_total += 1

--- a/src/rov_firmware/main.py
+++ b/src/rov_firmware/main.py
@@ -6,6 +6,7 @@ import traceback
 
 from serial import SerialException
 
+from .diagnostics import FieldDiagnostics
 from .log import log_error
 from .models.log import LogLevel
 from .regulator import Regulator
@@ -71,6 +72,10 @@ async def main() -> None:
             asyncio.create_task(mcu.read_loop(), name="mcu.read_loop"),
             asyncio.create_task(thrusters.send_loop(), name="thrusters.send_loop"),
             asyncio.create_task(ws_server.wait_closed(), name="ws_server.wait_closed"),
+            asyncio.create_task(
+                FieldDiagnostics(state, serial_manager, mcu, thrusters).run(),
+                name="field_diagnostics",
+            ),
         ]
         _ = await asyncio.gather(*tasks)
     except asyncio.CancelledError:

--- a/src/rov_firmware/regulator.py
+++ b/src/rov_firmware/regulator.py
@@ -637,6 +637,10 @@ class Regulator:
             dtype=np.float32,
         )
 
+    def diagnostic_output(self) -> list[float]:
+        """Return the last computed contribution without advancing the controller."""
+        return self._regulator_direction_vector.tolist()
+
     def apply_regulator_to_direction_vector(
         self, direction_vector: NDArray[np.float32]
     ) -> NDArray[np.float32]:

--- a/src/rov_firmware/sensors/mcu.py
+++ b/src/rov_firmware/sensors/mcu.py
@@ -42,6 +42,7 @@ from ..constants import (
     MCU_TELEMETRY_TYPE_VOLTAGE,
     NUM_MOTORS,
 )
+from ..diagnostics import log_diagnostic
 from ..esc_firmware import (
     check_esc_firmware_confirmation,
     is_valid_esc_firmware_version,
@@ -72,6 +73,7 @@ _RUNTIME_CONFIG_STATUS_PACKET_START_TOKEN = bytes(
 _RELEASE_VERSION_PACKET_START_TOKEN = bytes((MCU_RELEASE_VERSION_START_BYTE,))
 _ESC_FIRMWARE_STATUS_START_TOKEN = bytes((ESC_FIRMWARE_USB_STATUS_START_BYTE,))
 _TELEMETRY_FIELDS = ("erpm", "voltage", "temperature", "current", "signal_quality")
+_INVALID_PACKET_LOG_INTERVAL_S = 5.0
 _ESC_VERSION_TYPES = (
     MCU_TELEMETRY_TYPE_ESC_VERSION_LENGTH,
     MCU_TELEMETRY_TYPE_ESC_VERSION_CHUNK,
@@ -118,6 +120,17 @@ class McuSensor:
         self._last_telemetry_time: list[list[float]] = [
             [0.0] * len(_TELEMETRY_FIELDS) for _ in range(NUM_MOTORS)
         ]
+        self._diagnostic_times = [
+            [0.0] * len(_TELEMETRY_FIELDS) for _ in range(NUM_MOTORS)
+        ]
+        self._diagnostic_values: list[list[int | float | None]] = [
+            [None] * len(_TELEMETRY_FIELDS) for _ in range(NUM_MOTORS)
+        ]
+        self._diagnostic_generation = serial_manager.connection_generation
+        self._diagnostic_erpm_min: list[int | None] = [None] * NUM_MOTORS
+        self._diagnostic_erpm_max: list[int | None] = [None] * NUM_MOTORS
+        self.invalid_usb_packets = 0
+        self._last_invalid_log = float("-inf")
         self._startup_time: float = time.monotonic()
         self._flash_task: asyncio.Task[None] | None = None
         self._mcu_auto_flash_attempted = False
@@ -170,6 +183,16 @@ class McuSensor:
         return data
 
     def _consume_read_buffer(self, read_buffer: bytearray, data: bytes) -> None:
+        if self._diagnostic_generation != self.serial_manager.connection_generation:
+            self._diagnostic_generation = self.serial_manager.connection_generation
+            self._diagnostic_times = [
+                [0.0] * len(_TELEMETRY_FIELDS) for _ in range(NUM_MOTORS)
+            ]
+            self._diagnostic_values = [
+                [None] * len(_TELEMETRY_FIELDS) for _ in range(NUM_MOTORS)
+            ]
+            self._diagnostic_erpm_min = [None] * NUM_MOTORS
+            self._diagnostic_erpm_max = [None] * NUM_MOTORS
         read_buffer.extend(data)
         search_start = 0
 
@@ -248,6 +271,8 @@ class McuSensor:
         packet = memoryview(read_buffer)[start_idx:end_idx]
         if self._validate_telemetry_packet(packet):
             self._update_telemetry(packet)
+        else:
+            self._record_invalid_packet(packet)
         return end_idx
 
     def _try_consume_telemetry_batch(
@@ -267,6 +292,8 @@ class McuSensor:
         packet = memoryview(read_buffer)[start_idx:end_idx]
         if self._validate_telemetry_batch_packet(packet):
             self._update_telemetry_batch(packet)
+        else:
+            self._record_invalid_packet(packet)
         return end_idx
 
     @staticmethod
@@ -292,6 +319,8 @@ class McuSensor:
         packet = memoryview(read_buffer)[start_idx:end_idx]
         if self._validate_runtime_config_status_packet(packet):
             self._handle_runtime_config_status_packet(packet)
+        else:
+            self._record_invalid_packet(packet)
         return end_idx
 
     def _try_consume_release_version(
@@ -309,7 +338,62 @@ class McuSensor:
         packet = memoryview(read_buffer)[start_idx:end_idx]
         if self._validate_release_version_packet(packet):
             self._handle_release_version_packet(packet)
+        else:
+            self._record_invalid_packet(packet)
         return end_idx
+
+    def _record_invalid_packet(self, packet: bytes | bytearray | memoryview) -> None:
+        self.invalid_usb_packets += 1
+        now = time.monotonic()
+        if now - self._last_invalid_log >= _INVALID_PACKET_LOG_INTERVAL_S:
+            log_diagnostic(
+                "invalid_usb_packet",
+                generation=self.serial_manager.connection_generation,
+                count=self.invalid_usb_packets,
+                packet_bytes=len(packet),
+                first_32_bytes_hex=bytes(packet[:32]).hex(),
+            )
+            self._last_invalid_log = now
+
+    def diagnostic_snapshot(self, now: float) -> list[dict[str, object]]:
+        """Last-known values and ages, separate from expired live telemetry."""
+        channels: list[dict[str, object]] = []
+        for channel in range(NUM_MOTORS):
+            row: dict[str, object] = {"channel": channel + 1}
+            same_generation = (
+                self._diagnostic_generation == self.serial_manager.connection_generation
+            )
+            for field_id, field in enumerate(_TELEMETRY_FIELDS):
+                updated = (
+                    self._diagnostic_times[channel][field_id]
+                    if same_generation
+                    else 0.0
+                )
+                age = max(0.0, now - updated) if updated > 0 else None
+                last_value = (
+                    self._diagnostic_values[channel][field_id] if updated > 0 else None
+                )
+                row[field] = (
+                    last_value
+                    if age is not None and age <= MCU_TELEMETRY_STALE_TIMEOUT_S
+                    else None
+                )
+                row[f"{field}_age_s"] = None if age is None else round(age, 3)
+                if field == "erpm":
+                    row["last_erpm"] = last_value
+                    row["erpm_stale"] = (
+                        age is not None and age > MCU_TELEMETRY_STALE_TIMEOUT_S
+                    )
+            row["erpm_min_since_sample"] = (
+                self._diagnostic_erpm_min[channel] if same_generation else None
+            )
+            row["erpm_max_since_sample"] = (
+                self._diagnostic_erpm_max[channel] if same_generation else None
+            )
+            channels.append(row)
+        self._diagnostic_erpm_min = [None] * NUM_MOTORS
+        self._diagnostic_erpm_max = [None] * NUM_MOTORS
+        return channels
 
     @staticmethod
     def _find_start_byte(buf: bytearray, start: int) -> int:
@@ -603,6 +687,36 @@ class McuSensor:
                 else:
                     self.state.mcu_telemetry.signal_quality[global_id] = value / 100
                     self.state.mcu_telemetry.signal_quality_valid[global_id] = True
+
+            self._record_diagnostic_telemetry(global_id, packet_type, value)
+
+    def _record_diagnostic_telemetry(
+        self, channel: int, packet_type: int, raw_value: int
+    ) -> None:
+        self._diagnostic_times[channel][packet_type] = self._last_telemetry_time[
+            channel
+        ][packet_type]
+        field = _TELEMETRY_FIELDS[packet_type]
+        value = getattr(self.state.mcu_telemetry, field)[channel]
+        if packet_type == MCU_TELEMETRY_TYPE_CURRENT:
+            value = raw_value  # Keep signed wire readings; never change live current policy.
+        elif (
+            packet_type == MCU_TELEMETRY_TYPE_SIGNAL_QUALITY
+            and not self.state.mcu_telemetry.signal_quality_valid[channel]
+        ):
+            value = None
+        elif packet_type == MCU_TELEMETRY_TYPE_ERPM:
+            low, high = (
+                self._diagnostic_erpm_min[channel],
+                self._diagnostic_erpm_max[channel],
+            )
+            self._diagnostic_erpm_min[channel] = (
+                value if low is None else min(low, value)
+            )
+            self._diagnostic_erpm_max[channel] = (
+                value if high is None else max(high, value)
+            )
+        self._diagnostic_values[channel][packet_type] = value
 
     def _update_esc_firmware_version(
         self, global_id: int, packet_type: int, value: int

--- a/src/rov_firmware/sensors/pi_power.py
+++ b/src/rov_firmware/sensors/pi_power.py
@@ -8,6 +8,11 @@ RPI_VOLTAGE_SENSOR_NAME = "rpi_volt"
 
 
 def is_pi_undervoltage_detected(hwmon_root: Path = HWMON_ROOT) -> bool:
+    """Keep the existing status policy: unavailable is not an undervoltage alarm."""
+    return read_pi_undervoltage(hwmon_root) is True
+
+
+def read_pi_undervoltage(hwmon_root: Path = HWMON_ROOT) -> bool | None:
     """Return whether the Raspberry Pi firmware detected input undervoltage.
 
     The ``raspberrypi-hwmon`` kernel driver polls the firmware throttling flags
@@ -19,9 +24,8 @@ def is_pi_undervoltage_detected(hwmon_root: Path = HWMON_ROOT) -> bool:
         hwmon_root: hwmon class directory, injectable for tests.
 
     Returns:
-        True while the kernel's Raspberry Pi voltage alarm is asserted. Missing
-        or unreadable hwmon data is treated as unavailable rather than as an
-        undervoltage event.
+        True while the alarm is asserted, False for a measured clear alarm,
+        or None when monitoring is unavailable.
     """
     try:
         for device in hwmon_root.glob("hwmon*"):
@@ -30,10 +34,10 @@ def is_pi_undervoltage_detected(hwmon_root: Path = HWMON_ROOT) -> bool:
                 if sensor_name != RPI_VOLTAGE_SENSOR_NAME:
                     continue
                 alarm = (device / "in0_lcrit_alarm").read_text(encoding="ascii")
-                return alarm.strip() == "1"
-            except OSError:
+                return {"0": False, "1": True}.get(alarm.strip())
+            except (OSError, UnicodeError):
                 continue
     except OSError:
-        return False
+        return None
 
-    return False
+    return None

--- a/src/rov_firmware/serial.py
+++ b/src/rov_firmware/serial.py
@@ -12,6 +12,7 @@ from .constants import (
     MCU_RUNTIME_CONFIG_STATE_APPLYING,
     MCU_RUNTIME_CONFIG_STATE_REJECTED,
 )
+from .diagnostics import log_diagnostic
 from .log import log_error, log_info, log_warn
 from .models.toast import ToastContent
 from .rov_state import RovState
@@ -38,6 +39,7 @@ class SerialManager:
         self._connection_generation: int = 0
         self._mcu_protocol_config: tuple[str, int] | None = None
         self._mcu_protocol_request_id: int | None = None
+        self._last_status_diagnostic: tuple[int, int, int, str, int] | None = None
 
     async def _find_mcu_port(self, *, log_missing: bool = True) -> str | None:
         mcu_ports = list(Path("/dev/serial/by-id/").glob("usb-Raspberry_Pi_Pico*"))
@@ -107,6 +109,9 @@ class SerialManager:
                 self.state.system_status.thruster_protocol_error = None
                 self.state.system_health.mcu_healthy = True
                 log_info("MCU initialized successfully.")
+                log_diagnostic(
+                    "usb_open", port=serial_port, generation=self._connection_generation
+                )
                 return True
             except Exception as e:
                 await self._clear_connection_unlocked()
@@ -152,6 +157,12 @@ class SerialManager:
                 return
             if not self.state.mcu_flashing:
                 log_error(reason)
+            log_diagnostic(
+                "usb_lost",
+                generation=self._connection_generation,
+                pico_flashing=self.state.mcu_flashing,
+                reason=reason,
+            )
             await self._clear_connection_unlocked()
 
     def get_reader(self) -> asyncio.StreamReader:
@@ -207,6 +218,7 @@ class SerialManager:
     def begin_mcu_protocol_request(self, request_id: int) -> None:
         """Track the current correlated runtime-config request."""
         self._mcu_protocol_request_id = request_id
+        self._last_status_diagnostic = None
         self.state.system_status.thruster_control_ready = False
         self.state.system_status.thruster_protocol_state = "applying"
         self.state.system_status.thruster_protocol_error = None
@@ -220,6 +232,19 @@ class SerialManager:
         dshot_speed: int,
     ) -> None:
         """Apply a correlated runtime-config state reported by the MCU."""
+        diagnostic = (request_id, status, error, protocol, dshot_speed)
+        if diagnostic != self._last_status_diagnostic:
+            log_diagnostic(
+                "mcu_protocol_ack",
+                request_id=request_id,
+                expected_request_id=self._mcu_protocol_request_id,
+                status=status,
+                error=error,
+                protocol=protocol,
+                dshot_speed=dshot_speed,
+                generation=self._connection_generation,
+            )
+            self._last_status_diagnostic = diagnostic
         if request_id != self._mcu_protocol_request_id:
             return
         if status == MCU_RUNTIME_CONFIG_STATE_APPLYING:

--- a/src/rov_firmware/thrusters.py
+++ b/src/rov_firmware/thrusters.py
@@ -43,6 +43,7 @@ _CONFIG_ACK_WARNING_SECONDS = 5.0
 _CONFIG_ACK_TIMEOUT_SECONDS = 8.0
 _MCU_INFO_RETRY_INTERVAL_SECONDS = 1.0
 _MCU_INFO_ATTEMPTS = 3
+_CONTROL_DIAGNOSTIC_INTERVAL_SECONDS = 10.0
 
 
 class Thrusters:
@@ -85,6 +86,9 @@ class Thrusters:
         self._diagnostic_max_send_gap = 0.0
         self._diagnostic_late_sends = 0
         self._diagnostic_send_failures = 0
+        self._control_log_key: tuple[int, int, int, int, int] | None = None
+        self._control_log_time = float("-inf")
+        self._suppressed_control_logs = 0
 
         self.previous_direction_vector: NDArray[np.float32] = np.zeros(
             8, dtype=np.float32
@@ -661,13 +665,47 @@ class Thrusters:
         async with self.serial_manager.write_lock:
             writer.write(packet)
             await writer.drain()
+        self._record_control_diagnostic(
+            (
+                command,
+                request_id,
+                protocol,
+                dshot_speed,
+                self.serial_manager.connection_generation,
+            )
+        )
+
+    def _record_control_diagnostic(self, key: tuple[int, int, int, int, int]) -> None:
+        now = time.monotonic()
+        if (
+            key == self._control_log_key
+            and now - self._control_log_time < _CONTROL_DIAGNOSTIC_INTERVAL_SECONDS
+        ):
+            self._suppressed_control_logs += 1
+            return
+        if key != self._control_log_key:
+            if self._control_log_key is not None and self._suppressed_control_logs:
+                self._emit_control_diagnostic(
+                    "mcu_control_repeat_summary", self._control_log_key
+                )
+            self._suppressed_control_logs = 0
+        self._emit_control_diagnostic("mcu_control_sent", key)
+        self._control_log_key = key
+        self._control_log_time = now
+        self._suppressed_control_logs = 0
+
+    def _emit_control_diagnostic(
+        self, event: str, key: tuple[int, int, int, int, int]
+    ) -> None:
+        command, request_id, protocol, speed, generation = key
         log_diagnostic(
-            "mcu_control_sent",
+            event,
             command=command,
             request_id=request_id,
             protocol=protocol,
-            dshot_speed=dshot_speed,
-            generation=self.serial_manager.connection_generation,
+            dshot_speed=speed,
+            generation=generation,
+            suppressed_attempts=self._suppressed_control_logs,
         )
 
     async def _ensure_mcu_info_requested(self, writer: StreamWriter) -> None:

--- a/src/rov_firmware/thrusters.py
+++ b/src/rov_firmware/thrusters.py
@@ -29,6 +29,7 @@ from .constants import (
     THRUSTER_TEST_TOAST_ID,
     THRUSTER_TIMEOUT_MS,
 )
+from .diagnostics import log_diagnostic
 from .log import log_error, log_warn
 from .models.toast import ToastVariant
 from .regulator import Regulator
@@ -76,6 +77,14 @@ class Thrusters:
         self._info_generation = -1
         self._info_attempts = 0
         self._last_info_attempt_time = 0.0
+        self._diagnostic_last_command: list[int] | None = None
+        self._diagnostic_command_min: list[int] | None = None
+        self._diagnostic_command_max: list[int] | None = None
+        self._diagnostic_last_send = 0.0
+        self._diagnostic_generation = -1
+        self._diagnostic_max_send_gap = 0.0
+        self._diagnostic_late_sends = 0
+        self._diagnostic_send_failures = 0
 
         self.previous_direction_vector: NDArray[np.float32] = np.zeros(
             8, dtype=np.float32
@@ -559,6 +568,30 @@ class Thrusters:
             action=None,
         )
 
+    def diagnostic_snapshot(self, now: float) -> dict[str, object]:
+        """Observe host USB writes, not proof of Pico/ESC command acceptance."""
+        snapshot: dict[str, object] = {
+            "last_usb_command": self._diagnostic_last_command,
+            "usb_command_min_since_sample": self._diagnostic_command_min,
+            "usb_command_max_since_sample": self._diagnostic_command_max,
+            "last_usb_write_age_s": round(max(0.0, now - self._diagnostic_last_send), 3)
+            if self._diagnostic_last_send
+            else None,
+            "write_generation": self._diagnostic_generation,
+            "send_frequency_hz": THRUSTER_SEND_FREQUENCY,
+            "max_write_gap_s": round(self._diagnostic_max_send_gap, 4),
+            "write_gaps_over_two_periods": self._diagnostic_late_sends,
+            "write_failures": self._diagnostic_send_failures,
+            "last_regulator_contribution": self.regulator.diagnostic_output(),
+            "test_channel_index": self.state.thrusters.test_thruster,
+            "auto_tuning": self.state.regulator.auto_tuning_active,
+        }
+        self._diagnostic_max_send_gap = 0.0
+        self._diagnostic_late_sends = 0
+        self._diagnostic_command_min = None
+        self._diagnostic_command_max = None
+        return snapshot
+
     async def _send_packet(
         self, writer: StreamWriter, thrust_values: list[int]
     ) -> None:
@@ -571,6 +604,36 @@ class Thrusters:
         async with self.serial_manager.write_lock:
             writer.write(packet)
             await writer.drain()
+        now = time.monotonic()
+        generation = self.serial_manager.connection_generation
+        if self._diagnostic_generation == generation and self._diagnostic_last_send:
+            gap = now - self._diagnostic_last_send
+            self._diagnostic_max_send_gap = max(self._diagnostic_max_send_gap, gap)
+            if gap > 2 / THRUSTER_SEND_FREQUENCY:
+                self._diagnostic_late_sends += 1
+        if (
+            self._diagnostic_command_min is None
+            or self._diagnostic_generation != generation
+        ):
+            self._diagnostic_command_min = thrust_values.copy()
+            self._diagnostic_command_max = thrust_values.copy()
+        else:
+            self._diagnostic_command_min = [
+                min(old, new)
+                for old, new in zip(
+                    self._diagnostic_command_min, thrust_values, strict=True
+                )
+            ]
+            if self._diagnostic_command_max is not None:
+                self._diagnostic_command_max = [
+                    max(old, new)
+                    for old, new in zip(
+                        self._diagnostic_command_max, thrust_values, strict=True
+                    )
+                ]
+        self._diagnostic_last_command = thrust_values.copy()
+        self._diagnostic_last_send = now
+        self._diagnostic_generation = generation
 
     def _new_control_request_id(self) -> int:
         self._next_control_request_id = (self._next_control_request_id % 255) + 1
@@ -598,6 +661,14 @@ class Thrusters:
         async with self.serial_manager.write_lock:
             writer.write(packet)
             await writer.drain()
+        log_diagnostic(
+            "mcu_control_sent",
+            command=command,
+            request_id=request_id,
+            protocol=protocol,
+            dshot_speed=dshot_speed,
+            generation=self.serial_manager.connection_generation,
+        )
 
     async def _ensure_mcu_info_requested(self, writer: StreamWriter) -> None:
         generation = self.serial_manager.connection_generation
@@ -683,7 +754,7 @@ class Thrusters:
             self.state.system_status.thruster_protocol_state = "failed"
             self.state.system_status.thruster_protocol_error = (
                 "The MCU did not finish applying the selected thruster protocol. "
-                "Reflash the MCU firmware or reconnect its USB cable."
+                "Reflash the Pico (Firmware → Flash Pico) or reconnect its USB cable."
             )
             self._pending_config_since = now
 
@@ -755,6 +826,7 @@ class Thrusters:
                 await self._send_packet(writer, thrust_values)
                 return True
             except Exception as e:
+                self._diagnostic_send_failures += 1
                 log_error(f"Thruster send_packet failed (attempt {attempt + 1}): {e}")
                 await asyncio.sleep(0.1)
         return False

--- a/src/rov_firmware/websocket/server.py
+++ b/src/rov_firmware/websocket/server.py
@@ -11,7 +11,14 @@ from websockets import Server, ServerConnection
 from websockets.exceptions import ConnectionClosed
 
 from ..constants import CRASH_LOG_SEND_TIMEOUT_S
-from ..log import flush_pending_logs, log_error, log_info, log_warn
+from ..log import (
+    flush_pending_logs,
+    get_local_logger,
+    log_error,
+    log_info,
+    log_warn,
+    stamp_log_message,
+)
 from ..models.log import LogEntry, LogLevel, LogOrigin
 from ..rov_state import RovState
 from ..serial import SerialManager
@@ -24,7 +31,7 @@ from .send.telemetry import build_telemetry
 from .state import websocket_state
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_local_logger()
 
 websocket_message_adapter = TypeAdapter(WebsocketMessage)
 
@@ -53,6 +60,7 @@ class WebsocketServer:
         """
         self.client = websocket
         websocket_state.is_client_connected = True
+        websocket_state.connection_generation += 1
         log_info(
             f"Client connected: {cast(tuple[str, int] | None, websocket.remote_address)}."
         )
@@ -145,6 +153,15 @@ class WebsocketServer:
             level: The log level for the frame.
             message: The log message body.
         """
+        message = stamp_log_message(message)
+        _logger.log(
+            {
+                LogLevel.INFO: logging.INFO,
+                LogLevel.WARN: logging.WARNING,
+                LogLevel.ERROR: logging.ERROR,
+            }[level],
+            message,
+        )
         payload = LogEntry(origin=LogOrigin.FIRMWARE, level=level, message=message)
         try:
             await self.send_frame(

--- a/src/rov_firmware/websocket/state.py
+++ b/src/rov_firmware/websocket/state.py
@@ -12,6 +12,7 @@ class AsyncWebSocketState(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(arbitrary_types_allowed=True)
 
     is_client_connected: bool = False
+    connection_generation: int = 0
     main_event_loop: asyncio.AbstractEventLoop | None = None
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,248 @@
+import asyncio
+import hashlib
+import json
+import time
+from typing import Any, cast
+
+import pytest
+
+from rov_firmware import diagnostics
+from rov_firmware.constants import (
+    MCU_TELEMETRY_SIGNAL_QUALITY_UNAVAILABLE,
+    MCU_TELEMETRY_STALE_TIMEOUT_S,
+    MCU_TELEMETRY_TYPE_CURRENT,
+    MCU_TELEMETRY_TYPE_ERPM,
+    MCU_TELEMETRY_TYPE_SIGNAL_QUALITY,
+)
+from rov_firmware.regulator import Regulator
+from rov_firmware.sensors import mcu as mcu_module
+from rov_firmware.sensors.mcu import McuSensor
+from rov_firmware.sensors.pi_power import read_pi_undervoltage
+from rov_firmware.serial import SerialManager
+from rov_firmware.thrusters import Thrusters
+from rov_firmware.websocket.state import websocket_state
+
+
+@pytest.fixture
+def recorder(rov_state, monkeypatch):
+    serial = SerialManager(rov_state)
+    mcu = McuSensor(rov_state, serial)
+    thrusters = Thrusters(rov_state, serial, Regulator(rov_state))
+    recorder = diagnostics.FieldDiagnostics(rov_state, serial, mcu, thrusters)
+    events = []
+    monkeypatch.setattr(
+        diagnostics,
+        "log_diagnostic",
+        lambda event, **fields: events.append((event, fields)),
+    )
+    monkeypatch.setattr(websocket_state, "is_client_connected", False)
+    rov_state.system_health.mcu_healthy = True
+    rov_state.system_status.thruster_control_ready = True
+    rov_state.system_status.thruster_protocol_state = "ready"
+    return recorder, events
+
+
+def test_summary_rate_and_history_are_bounded(recorder):
+    recorder, events = recorder
+    for now in range(100, 175):
+        recorder.sample(float(now), undervoltage=False)
+    assert len(recorder._history) == 60
+    assert len([event for event, _ in events if event == "snapshot"]) == 8
+    assert not any(event == "fault_history" for event, _ in events)
+    # No giant messages that the journal would truncate or the viewer cannot wrap.
+    assert max(len(json.dumps(fields)) for _, fields in events) < 16_384
+
+
+def test_fault_history_is_frozen_and_rate_limited(recorder):
+    recorder, events = recorder
+    for now in range(100, 160):
+        recorder.sample(float(now), undervoltage=False)
+    recorder.sample(160.0, undervoltage=True)
+    dumped = [fields for event, fields in events if event == "history_sample"]
+    assert len(dumped) == 60
+    assert dumped[0]["mono_s"] == 101.0
+    assert dumped[-1]["pi_undervoltage"] is True
+    for now in range(161, 180):
+        recorder.sample(float(now), undervoltage=now % 2 == 0)
+    assert len([event for event, _ in events if event == "fault_history"]) == 1
+    assert dumped[0]["pi_undervoltage"] is False
+
+
+def test_connect_and_config_changes_repeat_context_without_private_fields(
+    recorder, monkeypatch
+):
+    recorder, events = recorder
+    recorder.sample(100.0, undervoltage=False)
+    monkeypatch.setattr(websocket_state, "is_client_connected", True)
+    recorder.sample(101.0, undervoltage=False)
+    recorder.state.rov_config.dshot_speed = 600
+    recorder.sample(102.0, undervoltage=False)
+    configs = [fields for event, fields in events if event == "configuration"]
+    assert len(configs) == 3
+    assert configs[-1]["config"]["dshot_speed"] == 600
+    assert "ip_address" not in configs[-1]["config"]
+    assert "rov_name" not in configs[-1]["config"]
+    assert "utc_clock_verified" in configs[-1]
+
+
+def test_fault_during_cooldown_is_reported_when_cooldown_expires(recorder):
+    recorder, events = recorder
+    recorder.sample(100.0, undervoltage=True)
+    recorder.state.system_status.thruster_protocol_state = "failed"
+    recorder.sample(110.0, undervoltage=True)
+    assert len([event for event, _ in events if event == "fault_history"]) == 1
+    recorder.sample(130.0, undervoltage=True)
+    history = [fields for event, fields in events if event == "fault_history"]
+    assert history[-1]["reasons"] == {"protocol_failed": 110.0}
+
+
+def test_unavailable_power_is_not_a_measured_healthy_supply(recorder, tmp_path):
+    recorder, events = recorder
+    assert read_pi_undervoltage(tmp_path) is None
+    recorder.sample(100.0, undervoltage=None)
+    snapshot = next(fields for event, fields in events if event == "snapshot")
+    assert snapshot["pi_undervoltage"] is None
+
+
+def test_sampler_uses_capture_time_after_power_probe(recorder, monkeypatch):
+    recorder, _ = recorder
+    probe_ended = []
+    samples = []
+
+    def power_probe():
+        time.sleep(0.01)
+        probe_ended.append(time.monotonic())
+        return False
+
+    def capture(now, **fields):
+        samples.append((now, fields))
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(diagnostics, "firmware_manifest", lambda _: [])
+    monkeypatch.setattr(diagnostics, "read_pi_undervoltage", power_probe)
+    monkeypatch.setattr(recorder, "sample", capture)
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(recorder.run())
+    assert samples[0][0] >= probe_ended[0]
+    assert samples[0][1]["power_probe_s"] >= 0.01
+    assert samples[0][1]["scheduler_lag"] >= 0.01
+
+
+def test_manifest_hashes_only_images_not_keys_or_config(tmp_path):
+    image = tmp_path / "mcu-firmware" / "pico-v1.0.3-rc.6.uf2"
+    image.parent.mkdir()
+    image.write_bytes(b"binary\x00\x0aimage")
+    (image.parent / "private.key").write_text("do not read me")
+    entries = diagnostics.firmware_manifest(tmp_path)
+    assert entries == [
+        {
+            "file": image.name,
+            "sha256": hashlib.sha256(image.read_bytes()).hexdigest(),
+            "bytes": image.stat().st_size,
+        }
+    ]
+
+
+def test_telemetry_distinguishes_zero_missing_stale_and_short_rpm_dips(
+    recorder, monkeypatch
+):
+    recorder, _ = recorder
+    mcu = recorder.mcu
+    assert mcu.diagnostic_snapshot(100.0)[0]["erpm"] is None
+    monkeypatch.setattr(mcu_module.time, "monotonic", lambda: 100.0)
+    mcu._update_telemetry_item(0, MCU_TELEMETRY_TYPE_ERPM, 20)
+    mcu._update_telemetry_item(0, MCU_TELEMETRY_TYPE_ERPM, 0)
+    mcu._update_telemetry_item(0, MCU_TELEMETRY_TYPE_ERPM, 20)
+    mcu._update_telemetry_item(0, MCU_TELEMETRY_TYPE_CURRENT, -5)
+    mcu._update_telemetry_item(
+        0, MCU_TELEMETRY_TYPE_SIGNAL_QUALITY, MCU_TELEMETRY_SIGNAL_QUALITY_UNAVAILABLE
+    )
+    row = mcu.diagnostic_snapshot(100.2)[0]
+    assert row["erpm"] == 2000
+    assert row["erpm_min_since_sample"] == 0
+    assert row["erpm_max_since_sample"] == 2000
+    assert row["current"] == -5  # Raw wire reading; live safety policy unchanged.
+    assert recorder.state.mcu_telemetry.current[0] == 0
+    assert row["signal_quality"] is None
+    stale_time = 101.0 + MCU_TELEMETRY_STALE_TIMEOUT_S
+    monkeypatch.setattr(mcu_module.time, "monotonic", lambda: stale_time)
+    mcu._expire_stale_telemetry()
+    row = mcu.diagnostic_snapshot(stale_time)[0]
+    assert row["erpm"] is None
+    assert row["last_erpm"] == 2000
+    assert row["erpm_stale"] is True
+    assert row["erpm_min_since_sample"] is None
+
+
+def test_ten_second_summary_preserves_mid_window_dips(recorder, monkeypatch):
+    recorder, events = recorder
+    for now in range(100, 111):
+        monkeypatch.setattr(mcu_module.time, "monotonic", lambda now=now: float(now))
+        recorder.mcu._update_telemetry_item(
+            0, MCU_TELEMETRY_TYPE_ERPM, 0 if now == 105 else 20
+        )
+        command = 1500 if now == 105 else 1600
+        recorder.thrusters._diagnostic_command_min = [command] * 8
+        recorder.thrusters._diagnostic_command_max = [command] * 8
+        recorder.sample(float(now), undervoltage=False)
+    summary = [fields for event, fields in events if event == "snapshot"][-1]
+    assert summary["window_sample_count"] == 10
+    assert summary["esc"][0]["erpm"] == 2000
+    assert summary["esc"][0]["erpm_window_min"] == 0
+    assert summary["esc"][0]["erpm_window_max"] == 2000
+    assert summary["control"]["usb_command_window_min"] == [1500] * 8
+    assert summary["control"]["usb_command_window_max"] == [1600] * 8
+
+
+def test_new_usb_generation_cannot_reuse_previous_esc_values(recorder, monkeypatch):
+    recorder, _ = recorder
+    monkeypatch.setattr(mcu_module.time, "monotonic", lambda: 100.0)
+    recorder.mcu._update_telemetry_item(0, MCU_TELEMETRY_TYPE_ERPM, 30)
+    recorder.serial._connection_generation += 1
+    assert recorder.mcu.diagnostic_snapshot(100.1)[0]["erpm"] is None
+    recorder.mcu._consume_read_buffer(bytearray(), b"")
+    recorder.mcu._update_telemetry_item(0, MCU_TELEMETRY_TYPE_ERPM, 10)
+    row = recorder.mcu.diagnostic_snapshot(100.1)[0]
+    assert row["erpm"] == 1000
+    assert row["erpm_max_since_sample"] == 1000
+
+
+def test_malformed_usb_capture_is_counted_bounded_and_rate_limited(
+    recorder, monkeypatch
+):
+    recorder, events = recorder
+    monkeypatch.setattr(
+        mcu_module,
+        "log_diagnostic",
+        lambda event, **fields: events.append((event, fields)),
+    )
+    monkeypatch.setattr(mcu_module.time, "monotonic", lambda: 100.0)
+    for _ in range(1000):
+        recorder.mcu._record_invalid_packet(bytes(range(100)))
+    assert recorder.mcu.invalid_usb_packets == 1000
+    assert len(events) == 1
+    assert len(events[0][1]["first_32_bytes_hex"]) == 64
+
+
+def test_command_observation_does_not_modify_wire_packet(recorder):
+    recorder, _ = recorder
+
+    class Writer:
+        def __init__(self):
+            self.writes = []
+
+        def write(self, packet):
+            self.writes.append(bytes(packet))
+
+        async def drain(self):
+            pass
+
+    writer = Writer()
+    values = [1500] * 8
+    asyncio.run(recorder.thrusters._send_packet(cast(Any, writer), values))
+    values[0] = 1900
+    snapshot = recorder.thrusters.diagnostic_snapshot(200.0)
+    assert snapshot["last_usb_command"] == [1500] * 8
+    assert len(writer.writes) == 1
+    assert len(writer.writes[0]) == 18
+    assert snapshot["write_failures"] == 0

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,119 @@
+import asyncio
+from collections import deque
+import logging
+import threading
+import time
+
+import pytest
+
+from rov_firmware import log
+from rov_firmware.log_buffer import BoundedJournalHandler
+from rov_firmware.websocket.state import websocket_state
+
+
+@pytest.fixture
+def isolated_logs(monkeypatch):
+    queue = asyncio.Queue()
+    monkeypatch.setattr(log, "_pending_logs", deque(maxlen=log._MAX_PENDING_LOGS))
+    monkeypatch.setattr(log, "_dropped_logs", 0)
+    monkeypatch.setattr(log, "_flush_scheduled", False)
+    monkeypatch.setattr(log, "get_message_queue", lambda: queue)
+    monkeypatch.setattr(websocket_state, "is_client_connected", False)
+    monkeypatch.setattr(websocket_state, "main_event_loop", None)
+    return queue
+
+
+def test_early_logs_replay_with_generation_timestamp(isolated_logs, monkeypatch):
+    monkeypatch.setattr(log.time, "monotonic", lambda: 12.345)
+    log.log_error("early failure")
+    monkeypatch.setattr(log.time, "monotonic", lambda: 50.0)
+    asyncio.run(log.flush_pending_logs())
+    message = isolated_logs.get_nowait().payload.message
+    assert "mono_s=12.345" in message
+    assert "session=" in message and "boot=" in message and "utc=" in message
+    assert message.endswith("early failure")
+
+
+def test_offline_buffer_keeps_latest_logs_and_reports_loss(isolated_logs):
+    for index in range(log._MAX_PENDING_LOGS + 4):
+        log.log_info(f"entry-{index}")
+    asyncio.run(log.flush_pending_logs())
+    warning = isolated_logs.get_nowait().payload.message
+    assert "discarded 4 older records" in warning
+    assert isolated_logs.get_nowait().payload.message.endswith("entry-4")
+    remaining = []
+    while not isolated_logs.empty():
+        remaining.append(isolated_logs.get_nowait())
+    assert remaining[-1].payload.message.endswith("entry-103")
+    assert not log._pending_logs
+    assert log._dropped_logs == 0
+
+
+def test_connected_logs_are_in_both_journal_and_stream(
+    isolated_logs, monkeypatch, caplog
+):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(log._logger, "propagate", True)
+
+    async def run():
+        monkeypatch.setattr(
+            websocket_state, "main_event_loop", asyncio.get_running_loop()
+        )
+        monkeypatch.setattr(websocket_state, "is_client_connected", True)
+        log.log_warn("connected failure")
+        message = await asyncio.wait_for(isolated_logs.get(), 1)
+        assert message.payload.message.endswith("connected failure")
+        assert not log._pending_logs
+
+    asyncio.run(run())
+    assert sum("connected failure" in record.message for record in caplog.records) == 1
+
+
+def test_slow_client_backlog_is_bounded_without_dropping_control(isolated_logs):
+    control = object()
+    for _ in range(log._MAX_LOG_QUEUE_DEPTH):
+        isolated_logs.put_nowait(control)
+    for index in range(1500):
+        log.log_info(f"slow-client-{index}")
+    asyncio.run(log.flush_pending_logs())
+    assert isolated_logs.qsize() == log._MAX_LOG_QUEUE_DEPTH
+    assert len(log._pending_logs) == log._MAX_PENDING_LOGS
+    assert log._dropped_logs == 1400
+    while not isolated_logs.empty():
+        assert isolated_logs.get_nowait() is control
+    asyncio.run(log.flush_pending_logs())
+    assert "discarded 1400" in isolated_logs.get_nowait().payload.message
+    replay = []
+    while not isolated_logs.empty():
+        replay.append(isolated_logs.get_nowait())
+    assert replay[-1].payload.message.endswith("slow-client-1499")
+
+
+def test_blocked_journal_sink_cannot_block_producers():
+    entered = threading.Event()
+    release = threading.Event()
+    received = []
+
+    class SlowSink(logging.Handler):
+        def emit(self, record):
+            entered.set()
+            release.wait(2)
+            received.append(record.getMessage())
+
+    handler = BoundedJournalHandler(SlowSink(), capacity=4)
+    record = logging.LogRecord("test", logging.INFO, "", 0, "first", (), None)
+    handler.handle(record)
+    assert entered.wait(1)
+    try:
+        started = time.perf_counter()
+        for index in range(100):
+            handler.handle(
+                logging.LogRecord(
+                    "test", logging.INFO, "", 0, f"record-{index}", (), None
+                )
+            )
+        assert time.perf_counter() - started < 0.1
+        assert handler._records.qsize() == 4
+        assert handler.dropped_total == 96
+    finally:
+        release.set()

--- a/tests/test_log_concurrency.py
+++ b/tests/test_log_concurrency.py
@@ -1,0 +1,212 @@
+import asyncio
+from collections import deque
+import logging
+import queue
+import threading
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from rov_firmware import log
+from rov_firmware.constants import CRASH_LOG_SEND_TIMEOUT_S
+from rov_firmware.log_buffer import BoundedJournalHandler
+from rov_firmware.models.log import LogLevel
+from rov_firmware.websocket import server
+
+
+class ExitRaceLock:
+    """Insert a real producer after the empty decision, before the flag reset."""
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.exits = 0
+
+    def __enter__(self):
+        self.lock.acquire()
+        return self
+
+    def __exit__(self, *_args):
+        self.exits += 1
+        trigger = self.exits == 2
+        self.lock.release()
+        if trigger:
+            producer = threading.Thread(
+                target=lambda: log.log_info("arrived during flusher exit"), daemon=True
+            )
+            producer.start()
+            producer.join(timeout=2)
+            assert not producer.is_alive()
+
+
+@pytest.fixture
+def isolated_stream(monkeypatch):
+    stream = asyncio.Queue()
+    monkeypatch.setattr(log, "_pending_logs", deque(maxlen=log._MAX_PENDING_LOGS))
+    monkeypatch.setattr(log, "_pending_lock", threading.Lock())
+    monkeypatch.setattr(log, "_dropped_logs", 0)
+    monkeypatch.setattr(log, "_flush_scheduled", False)
+    monkeypatch.setattr(log, "get_message_queue", lambda: stream)
+    monkeypatch.setattr(log.websocket_state, "is_client_connected", True)
+    monkeypatch.setattr(log.websocket_state, "main_event_loop", None)
+    monkeypatch.setattr(log._logger, "handlers", [logging.NullHandler()])
+    monkeypatch.setattr(log._logger, "propagate", False)
+    return stream
+
+
+def test_threaded_arrival_during_flusher_exit_is_delivered_without_another_log(
+    isolated_stream, monkeypatch
+):
+    monkeypatch.setattr(log, "_pending_lock", ExitRaceLock())
+    monkeypatch.setattr(log, "_flush_scheduled", True)
+
+    async def run():
+        monkeypatch.setattr(
+            log.websocket_state, "main_event_loop", asyncio.get_running_loop()
+        )
+        await log._flush_when_connected()
+        message = await asyncio.wait_for(isolated_stream.get(), timeout=1)
+        assert message.payload.message.endswith("arrived during flusher exit")
+        assert isolated_stream.empty()
+        assert not log._pending_logs
+        assert not log._flush_scheduled
+
+    asyncio.run(run())
+
+
+def test_cancelled_flusher_preserves_pending_logs_without_rescheduling(
+    isolated_stream, monkeypatch
+):
+    entered = asyncio.Event()
+    schedule = Mock()
+    monkeypatch.setattr(log, "_schedule_flush", schedule)
+    monkeypatch.setattr(log, "_flush_scheduled", True)
+    log.log_info("pending at cancellation")
+    schedule.reset_mock()
+
+    async def blocked_flush():
+        entered.set()
+        await asyncio.Future()
+
+    monkeypatch.setattr(log, "flush_pending_logs", blocked_flush)
+
+    async def run():
+        task = asyncio.create_task(log._flush_when_connected())
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        schedule.assert_not_called()
+        assert not log._flush_scheduled
+        assert len(log._pending_logs) == 1
+        assert isolated_stream.empty()
+
+    asyncio.run(run())
+
+
+class ConsumerRaceQueue(queue.Queue):
+    """Allow a consumer to drain after Full, before the producer handles it."""
+
+    def __init__(self):
+        super().__init__(maxsize=1)
+        self.full_observed = threading.Event()
+        self.consumed = threading.Event()
+
+    def put_nowait(self, item):
+        try:
+            super().put_nowait(item)
+        except queue.Full:
+            self.full_observed.set()
+            assert self.consumed.wait(timeout=2)
+            raise
+
+
+def test_consumer_winning_eviction_race_does_not_increment_drop_counts(monkeypatch):
+    # Use a controlled consumer instead of the handler's autonomous drain loop.
+    monkeypatch.setattr(BoundedJournalHandler, "_drain", lambda _self: None)
+    handler = BoundedJournalHandler(logging.NullHandler(), capacity=1)
+    records = ConsumerRaceQueue()
+    handler._records = records
+    old = logging.LogRecord("test", logging.INFO, "", 0, "old", (), None)
+    new = logging.LogRecord("test", logging.INFO, "", 0, "new", (), None)
+    records.put_nowait(old)
+    consumed = []
+
+    def consume():
+        if records.full_observed.wait(timeout=2):
+            consumed.append(records.get_nowait())
+            records.consumed.set()
+
+    consumer = threading.Thread(target=consume, daemon=True)
+    consumer.start()
+    try:
+        handler.handle(new)
+    finally:
+        consumer.join(timeout=3)
+        handler.close()
+    assert not consumer.is_alive()
+    assert consumed == [old]
+    assert records.get_nowait() is new
+    assert records.empty()
+    assert handler._dropped == 0
+    assert handler.dropped_total == 0
+
+
+class BlockedSink(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.entered = threading.Event()
+        self.unblock = threading.Event()
+        self.timed_out = threading.Event()
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
+        self.entered.set()
+        if not self.unblock.wait(timeout=5):
+            self.timed_out.set()
+
+
+@pytest.mark.parametrize("send_fails", [False, True])
+def test_crash_and_internal_error_logging_use_bounded_nonblocking_journal(
+    monkeypatch, send_fails
+):
+    # Assert the production routing, not a replacement logger injected into server.
+    assert server._logger is log.get_local_logger()
+    assert not server._logger.propagate
+    assert any(
+        isinstance(handler, BoundedJournalHandler)
+        for handler in server._logger.handlers
+    )
+    sink = BlockedSink()
+    handler = BoundedJournalHandler(sink, capacity=4)
+    monkeypatch.setattr(log.get_local_logger(), "handlers", [handler])
+    monkeypatch.setattr(log.get_local_logger(), "propagate", False)
+    instance = object.__new__(server.WebsocketServer)
+    send_frame = AsyncMock(
+        side_effect=OSError("synthetic socket failure") if send_fails else None
+    )
+    monkeypatch.setattr(instance, "send_frame", send_frame)
+
+    async def run():
+        for _ in range(12):
+            await instance.send_log_now(LogLevel.ERROR, "synthetic crash")
+
+    try:
+        log.get_local_logger().error("occupy journal worker")
+        assert sink.entered.wait(timeout=1)
+        asyncio.run(run())
+        # Every socket attempt finished while the journal worker remained blocked.
+        assert not sink.unblock.is_set()
+        assert not sink.timed_out.is_set()
+        assert send_frame.await_count == 12
+        assert handler._records.qsize() == 4
+        assert handler.dropped_total == 12 * (2 if send_fails else 1) - 4
+        frame = send_frame.await_args_list[0].args[0]
+        assert "session=" in frame.payload.message
+        assert frame.payload.message.endswith("synthetic crash")
+        assert send_frame.await_args_list[0].kwargs == {
+            "timeout": CRASH_LOG_SEND_TIMEOUT_S
+        }
+    finally:
+        sink.unblock.set()
+        handler.close()

--- a/tests/test_mcu_binary_transport.py
+++ b/tests/test_mcu_binary_transport.py
@@ -1,0 +1,131 @@
+"""Exercise the upload boundary with binary-valued lengths and sequence bytes."""
+
+import asyncio
+from functools import reduce
+from operator import xor
+import struct
+from typing import cast
+
+import pytest
+
+from rov_firmware import esc_firmware
+from rov_firmware.sensors.mcu import McuSensor
+
+
+class _PicoStagingTransport:
+    """Replay staging ACKs only; reject any command that could program an ESC."""
+
+    def __init__(self, reader: asyncio.StreamReader, *, crlf: bool):
+        self.reader = reader
+        self.crlf = crlf
+        self.offset = 0
+        self.sequence = 0
+        self.payload = bytearray()
+
+    def write(self, packet: bytes) -> None:
+        assert reduce(xor, packet[:-1], 0) == packet[-1]
+        if packet[0] == 0xE7:
+            transaction = packet[2]
+            if packet[1] == 1:  # BEGIN: RAM staging only
+                self.offset = 0
+                self.sequence = 0
+                self.payload.clear()
+                status = 1
+                value = struct.unpack_from("<H", packet, 3)[0]
+            else:
+                assert packet[1] == 5, "Only BEGIN and QUERY_OFFSET are permitted"
+                status = 2
+                value = self.offset
+        else:
+            assert packet[0] == 0xE8
+            transaction = packet[1]
+            sequence, offset, length = struct.unpack_from("<HHB", packet, 2)
+            chunk = packet[7 : 7 + length]
+            if sequence == self.sequence:
+                assert offset + length == self.offset
+                assert self.payload[offset : offset + length] == chunk
+            else:
+                assert sequence == self.sequence + 1
+                assert offset == self.offset
+                self.payload.extend(chunk)
+                self.sequence = sequence
+                self.offset += length
+            status = 2
+            value = self.offset
+        ack = struct.pack(
+            "<BBBBIBH", 0xE9, status, 0xFF, 0, value, transaction, self.sequence
+        )
+        ack += bytes((reduce(xor, ack, 0),))
+        self.reader.feed_data(ack.replace(b"\n", b"\r\n") if self.crlf else ack)
+
+    async def drain(self) -> None:
+        pass
+
+
+@pytest.mark.parametrize("crlf", [True, False])
+def test_full_upload_requires_binary_output_including_tenth_ack(monkeypatch, crlf):
+    monkeypatch.setattr(esc_firmware, "_UPLOAD_ACK_TIMEOUT_S", 0.01)
+    events = []
+    monkeypatch.setattr(
+        esc_firmware,
+        "log_diagnostic",
+        lambda event, **fields: events.append((event, fields)),
+    )
+    image = bytes(range(256)) * 108  # Exact 27,648-byte application region.
+
+    async def run():
+        reader = asyncio.StreamReader()
+        transport = _PicoStagingTransport(reader, crlf=crlf)
+        upload = esc_firmware._upload_image(
+            reader,
+            cast(asyncio.StreamWriter, transport),
+            image,
+            bytearray(),
+            transaction_id=1,
+        )
+        if crlf:
+            with pytest.raises(
+                esc_firmware.EscFirmwareUpdateError,
+                match=r"timed out at 504 bytes.*No ESC was modified",
+            ):
+                await upload
+            assert transport.offset == 560  # Chunk arrived; its ACK was corrupted.
+        else:
+            await upload
+            assert transport.payload == image
+            assert transport.sequence == 494
+
+    asyncio.run(run())
+    if crlf:
+        retries = [fields for event, fields in events if event == "esc_upload_retry"]
+        assert len(retries) == 3
+        assert retries[-1] == {
+            "transaction": 1,
+            "sequence": 10,
+            "last_acknowledged_bytes": 504,
+            "expected_bytes": 560,
+            "attempt": 3,
+        }
+        corrupt = [fields for event, fields in events if event == "esc_status_timeout"]
+        assert any("0d0a" in (fields["last_invalid_hex"] or "") for fields in corrupt)
+    else:
+        acks = [fields for event, fields in events if event == "esc_upload_ack"]
+        assert acks[-1]["acknowledged_bytes"] == len(image)
+        assert len(acks) < 16  # No per-chunk log flood.
+        assert all(fields["commit_sent"] is False for fields in acks)
+
+
+def test_ten_byte_release_identity_requires_binary_output():
+    packet = bytes.fromhex("d6 01 0a 31 2e 30 2e 33 2d 72 63 2e 35 c8")
+    assert McuSensor._validate_release_version_packet(packet)
+    assert not McuSensor._validate_release_version_packet(
+        packet.replace(b"\n", b"\r\n")
+    )
+
+
+def test_protocol_ack_request_ten_requires_binary_output():
+    packet = bytes.fromhex("d5 0a 02 00 01 2c 01 f1")
+    assert McuSensor._validate_runtime_config_status_packet(packet)
+    assert not McuSensor._validate_runtime_config_status_packet(
+        packet.replace(b"\n", b"\r\n")
+    )

--- a/tests/test_thrusters.py
+++ b/tests/test_thrusters.py
@@ -416,6 +416,25 @@ def test_protocol_config_logs_actionable_error_when_ack_stays_blocked(
     ]
 
 
+def test_protocol_timeout_points_to_the_flash_pico_button(rov_state):
+    serial_manager = _SerialManagerSpy()
+    thrusters = Thrusters(
+        rov_state,
+        cast(Any, serial_manager),
+        cast(Any, RegulatorController(rov_state)),
+    )
+    writer = _WriterSpy()
+    asyncio.run(thrusters._ensure_config_sent(cast(Any, writer)))
+    thrusters._protocol_reconnect_attempts = 1
+    thrusters._pending_config_since -= 9
+
+    assert not asyncio.run(thrusters._ensure_config_sent(cast(Any, writer)))
+    assert rov_state.system_status.thruster_protocol_state == "failed"
+    assert "(Firmware → Flash Pico)" in (
+        rov_state.system_status.thruster_protocol_error or ""
+    )
+
+
 def test_thruster_test_countdown_starts_after_first_command_write(
     thrusters, monkeypatch
 ):

--- a/tests/test_thrusters.py
+++ b/tests/test_thrusters.py
@@ -416,6 +416,43 @@ def test_protocol_config_logs_actionable_error_when_ack_stays_blocked(
     ]
 
 
+def test_control_log_suppression_never_suppresses_usb_writes(thrusters, monkeypatch):
+    events = []
+    now = [100.0]
+    monkeypatch.setattr(thrusters_module.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(
+        thrusters_module,
+        "log_diagnostic",
+        lambda event, **fields: events.append((event, fields)),
+    )
+    writer = _WriterSpy()
+
+    async def send(request_id):
+        await thrusters._send_control_packet(
+            cast(Any, writer), MCU_CONTROL_COMMAND_APPLY_CONFIG, request_id
+        )
+
+    async def run():
+        for _ in range(20):
+            await send(1)
+        assert len(events) == 1
+        now[0] = 110.0
+        await send(1)
+        assert events[-1][1]["suppressed_attempts"] == 19
+        await send(1)
+        await send(1)
+        await send(2)
+
+    asyncio.run(run())
+    assert len(writer.writes) == 24
+    assert writer.drains == 24
+    assert events[-2][0] == "mcu_control_repeat_summary"
+    assert events[-2][1]["request_id"] == 1
+    assert events[-2][1]["suppressed_attempts"] == 2
+    assert events[-1][1]["request_id"] == 2
+    assert events[-1][1]["suppressed_attempts"] == 0
+
+
 def test_protocol_timeout_points_to_the_flash_pico_button(rov_state):
     serial_manager = _SerialManagerSpy()
     thrusters = Thrusters(


### PR DESCRIPTION
RC8 still bundled MCU RC5, so Flash Pico could reinstall the USB CRLF corruption behind unreadable MCU versions and uploads stalling at 504 acknowledged bytes. This pins the already-released binary-safe RC6 images for Pico and Pico 2 and fixes the persistent boot/registration paths that allowed a reboot to restore the old system.

Field failures also need more evidence than a timeout toast. The existing debug stream now records firmware image hashes, Pi session/boot IDs and generation timestamps, protocol requests/ACKs, upload offsets/retries, and sampled command/telemetry context. One-second observations retain short eRPM and command extrema; normal summaries are emitted every ten seconds. Fault histories, offline replay, connected-client backlog, and journal output are bounded. Journal writes run outside the motor event loop, and dropped records are reported.

Missing measurements remain unavailable. USB throttle counts are explicitly distinguished from electrical pulse widths and ESC acceptance. No current-limit, packet-layout, ACK-policy, or automatic ESC-flashing changes; no version-compatibility checks added. Readiness guidance names `(Firmware → Flash Pico)`.

### Verification
- 266 Python tests; Ruff, typing, dependency-pin sync, Nix system build, and whitespace checks passed.
- Pi 3B/Pico/IMU rig: corrected boot configuration and MCU RC6 survived power cycling and software reboots. Manual Pico flashing, independent identity reporting, and PWM/DShot transitions passed.
- With the final diagnostics code, twelve 27,648-byte uploads completed and were ABORTed. No COMMIT or ESC programming was performed. One run recovered a timeout at transaction 255, sequence 151, offset 8,400; the new trace identifies it.
- Live status remained ready, with no malformed USB packets observed in the capture. Matching records reached both the WebSocket stream and Pi journal. The final one-minute capture had one host write gap over two 60 Hz periods, peaking at 37 ms; this is not a claim of hard-real-time behavior.

No ESCs were attached. Actual ESC programming, return-path signal integrity, and motor behavior still need powered hardware testing. Reboot after installing the corrected Pi system; if the Pico still reports no version, use Firmware → Flash Pico once the RC6 bundle is installed.

The app log-export/readiness PR uses the existing log envelope and can merge independently. RC6 is already published; this PR does not create a new release.

---
Generated by gpt-6-astra using the Pi harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added field diagnostics covering configuration, telemetry, thruster health, faults, firmware manifests, power status, and system performance.
  - Improved diagnostic visibility for MCU connections, USB communication, firmware updates, and thruster commands.
  - Added bounded, resilient logging that preserves recent messages and remains responsive during connection or journal delays.
  - Added persistent boot storage support for deployed systems.

- **Updates**
  - Updated Pico and Pico 2 firmware images to release candidate v1.0.3-rc.6.
  - Improved power monitoring by distinguishing unavailable readings from confirmed normal voltage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->