### PR TITLE
chore(release): v1.1.6-rc.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.1.6-rc.8"
+version = "1.1.6-rc.9"
 description = "Firmware for the Manafish ROV"
 license = "AGPL-3.0-or-later"
 requires-python = "==3.13.14"

--- a/uv.lock
+++ b/uv.lock
@@ -109,7 +109,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/56/33/26ec2e8049eaa2f07
 
 [[package]]
 name = "manafish"
-version = "1.1.6rc8"
+version = "1.1.6rc9"
 source = { editable = "." }
 dependencies = [
     { name = "bmi270" },


### PR DESCRIPTION
Prepare the approved `v1.1.6-rc.9` release of #94. Only the project and lockfile release identities change.

Ruff formatting/lint, typing, and all 267 Python tests pass. The tag-triggered workflow will build and sign the SD image before publication.

---
Generated by gpt-6-astra using the Pi harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to 1.1.6-rc.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->