### PR TITLE
chore(release): v1.1.6-rc.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ The app must accept nullable/fractional `currentDraw` before installing this Pi
 version. Install the AM32 raw-current restoration and product input policy on
 all eight ESCs using the old Pico first, then deploy the new Pico through an
 updated Pi bundle. Pi auto-flashing cannot enforce that ESC-first sequence.
-Without new MCU reports, current remains unavailable. Release pins are unchanged
-by these source changes and must be updated as a separate staged release.
+Without new MCU reports, current remains unavailable. This release bundles
+AM32 v2.21.0-rc.3 and Pico/Pico 2 v1.0.3-rc.7. Do not install this bundle before
+updating all eight ESCs with the old Pico; use a separate ESC-first staging step.
 
 ## Building the SD Image
 

--- a/flake.lock
+++ b/flake.lock
@@ -35,13 +35,13 @@
     "esc-firmware": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-A6ZJtmU5IFrZ5C7ycFpYjHfkcwiX13L+3PD5wZxQz7Y=",
+        "narHash": "sha256-Gn7hgiijDk8MVkoK3Q3V2Gi7v0Bm6p6NM6CBtibW5Iw=",
         "type": "file",
-        "url": "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.2/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin"
+        "url": "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.3/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.2/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin"
+        "url": "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.3/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin"
       }
     },
     "flake-compat": {
@@ -104,25 +104,25 @@
     "mcu-firmware-pico": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-d/JCL0IMIfk5RhAhmzBo7xR2B0feW1thU0hrRdMqF5A=",
+        "narHash": "sha256-Ey5BmC4tpYAwF8qjNNzFAjd02CCrdEPxIjnGFsmVvLE=",
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico-v1.0.3-rc.6.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.7/pico-v1.0.3-rc.7.uf2"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico-v1.0.3-rc.6.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.7/pico-v1.0.3-rc.7.uf2"
       }
     },
     "mcu-firmware-pico2": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-v48bAjdETqgCBsXZXIH3bCZazhCkC5FiaYkbAL5Ze5U=",
+        "narHash": "sha256-Xlf7FW31VQ3ha1D5B8kONNjdB8hjSc13O1oy5Zs/VXM=",
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico2-v1.0.3-rc.6.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.7/pico2-v1.0.3-rc.7.uf2"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico2-v1.0.3-rc.6.uf2"
+        "url": "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.7/pico2-v1.0.3-rc.7.uf2"
       }
     },
     "ms5837-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,15 +40,15 @@
       flake = false;
     };
     mcu-firmware-pico = {
-      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico-v1.0.3-rc.6.uf2";
+      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.7/pico-v1.0.3-rc.7.uf2";
       flake = false;
     };
     mcu-firmware-pico2 = {
-      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.6/pico2-v1.0.3-rc.6.uf2";
+      url = "https://github.com/manafishrov/mcu-firmware/releases/download/v1.0.3-rc.7/pico2-v1.0.3-rc.7.uf2";
       flake = false;
     };
     esc-firmware = {
-      url = "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.2/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin";
+      url = "https://github.com/manafishrov/AM32/releases/download/v2.21.0-rc.3/AM32_SKYSTARS_AM60_V2_F421_2.21.0.bin";
       flake = false;
     };
   };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manafish"
-version = "1.1.6-rc.9"
+version = "1.1.6-rc.10"
 description = "Firmware for the Manafish ROV"
 license = "AGPL-3.0-or-later"
 requires-python = "==3.13.14"

--- a/uv.lock
+++ b/uv.lock
@@ -109,7 +109,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/56/33/26ec2e8049eaa2f07
 
 [[package]]
 name = "manafish"
-version = "1.1.6rc9"
+version = "1.1.6rc10"
 source = { editable = "." }
 dependencies = [
     { name = "bmi270" },


### PR DESCRIPTION
Prepare firmware v1.1.6-rc.10 with the current-reporting changes merged in #96 and verified release artifacts for AM32 v2.21.0-rc.3 and Pico/Pico 2 v1.0.3-rc.7. Earlier binary-safe USB, persistent boot, and field diagnostics fixes remain included.

Update only the three firmware artifact inputs, their lock entries, the service version, and rollout documentation. The locked files' SHA-256 values match the published release downloads; the AM32 manifest, image size/identity, and Pico UF2 framing/identities were verified.

All 274 Python tests, Ruff formatting/lint, ty, Nix formatting/static checks, flake checks, and image dry-run evaluation pass. The full image is built by the release workflow after tagging. No deployment or flashing performed.

Install app v1.0.17-rc.13 before this Pi firmware. Install AM32 v2.21.0-rc.3 on all eight ESCs using the old Pico before installing this bundle: Pi auto-flashing can otherwise install the new Pico first. Current auto-zero is MCU-side, reporting-only, and assumes two shared-sensor boards. Sensor gain and PWM behavior remain unvalidated on hardware.

---
Generated by gpt-6-astra using the Pi harness.
